### PR TITLE
EMP-241: Remove DOB parameter

### DIFF
--- a/server/views/components/searchEformBox.njk
+++ b/server/views/components/searchEformBox.njk
@@ -1,12 +1,11 @@
 <div class="form-background govuk-!-padding-top-4 govuk-!-padding-left-4">
     <form action="/search-eform" method="POST">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-half">
+            <div class="govuk-grid-column-one-quarter">
                 {{ govukInput({
                     label: {
                         text: 'USN'
                     },
-                    classes: "govuk-input--width-10",
                     id: "usn",
                     name: "usn",
                     value: formValues.usn,
@@ -15,12 +14,11 @@
                     errorMessage: errors.messages.usn
                 }) }}
             </div>
-            <div class="govuk-grid-column-one-half">
+            <div class="govuk-grid-column-one-quarter">
                 {{ govukInput({
                     label: {
                         text: "Supplier account number"
                     },
-                    classes: "govuk-input--width-10",
                     id: "supplierAccountNumber",
                     name: "supplierAccountNumber",
                     value: formValues.supplierAccountNumber,
@@ -40,19 +38,6 @@
                     name: "clientName",
                     value: formValues.clientName,
                     errorMessage: errors.messages.clientName
-                }) }}
-            </div>
-            <div class="govuk-grid-column-one-half">
-                {{ govukInput({
-                    label: {
-                        text: "Client date of birth"
-                    },
-                    classes: "govuk-input--width-10",
-                    id: "clientDOB",
-                    name: "clientDOB",
-                    value: formValues.clientDOB,
-                    type: "date",
-                    errorMessage: errors.messages.clientDOB
                 }) }}
             </div>
         </div>

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -9,9 +9,9 @@
       <div class="govuk-width-container">
           <main class="govuk-main-wrapper">
               <h1 class="govuk-heading-l">Equiniti historical data</h1>
-              <span>You can generate reports or search for historical data eForm.</span>
+              <span >You can generate reports or search for historical data eForm.</span>
 
-              <p class="govuk-body">
+              <p class="govuk-body govuk-!-margin-top-7">
                   <a href="/generate-report" class="govuk-link govuk-link--no-visited-state">Generate reports</a>
               </p>
               <p class="govuk-body">


### PR DESCRIPTION
This ticket is about resolving the point 2 of this [ticket](https://dsdmoj.atlassian.net/browse/EMP-241)
- Remove `Client date of birth` parameter from the search eForm box
- The tests are keeping this parameter only because it will be implemented very soon in phase 2