### PR TITLE
EMP-307: Add support for subheadings in display configuration

### DIFF
--- a/server/@types/crmDisplay/index.d.ts
+++ b/server/@types/crmDisplay/index.d.ts
@@ -12,7 +12,7 @@ type DisplayField = {
   value: string
 }
 
-type FieldOrSubHeading = SubHeading | ConfigField | DisplayField
+type FieldOrSubHeading = ConfigField | DisplayField | SubHeading
 
 type SubSection = {
   title: string
@@ -43,14 +43,14 @@ type Navigation = {
 }
 
 export type {
+  ConfigField,
   CrmDisplayConfig,
   CrmType,
+  DisplayField,
+  FieldOrSubHeading,
   Navigation,
   NavigationItem,
   Section,
-  SubSection,
-  FieldOrSubHeading,
   SubHeading,
-  ConfigField,
-  DisplayField,
+  SubSection,
 }

--- a/server/@types/crmDisplay/index.d.ts
+++ b/server/@types/crmDisplay/index.d.ts
@@ -1,3 +1,7 @@
+type SubHeading = {
+  subHeading: string
+}
+
 type ConfigField = {
   label: string
   apiField: string
@@ -8,11 +12,11 @@ type DisplayField = {
   value: string
 }
 
-type Field = ConfigField | DisplayField
+type FieldOrSubHeading = SubHeading | ConfigField | DisplayField
 
 type SubSection = {
   title: string
-  fields: Array<Field>
+  fields: Array<FieldOrSubHeading>
 }
 
 type Section = {
@@ -38,4 +42,15 @@ type Navigation = {
   items: Array<NavigationItem>
 }
 
-export type { CrmDisplayConfig, CrmType, Navigation, NavigationItem, Section, SubSection, Field, ConfigField }
+export type {
+  CrmDisplayConfig,
+  CrmType,
+  Navigation,
+  NavigationItem,
+  Section,
+  SubSection,
+  FieldOrSubHeading,
+  SubHeading,
+  ConfigField,
+  DisplayField,
+}

--- a/server/services/config/crm5DisplayConfig.json
+++ b/server/services/config/crm5DisplayConfig.json
@@ -182,23 +182,23 @@
             },
             {
               "label": "Does your client or partner (if living with client as couple) get Income Support, Income Based Job Seeker's Allowance, Income Related Employment and Support Allowance or Guarantee State Pension Credit?",
-              "apiField": "ClientDetails.hasIncomeSupport"
+              "apiField": "CapitalDetails.hasIncomeSupport"
             },
             {
               "label": "How many dependants does your client have?",
-              "apiField": "ClientDetails.numOfDependants"
+              "apiField": "CapitalDetails.numOfDependants"
             },
             {
               "label": "Client",
-              "apiField": "ClientDetails.clientSavings"
+              "apiField": "CapitalDetails.clientSavings"
             },
             {
               "label": "Partner",
-              "apiField": "ClientDetails.partnerSavings"
+              "apiField": "CapitalDetails.partnerSavings"
             },
             {
               "label": "Total",
-              "apiField": "ClientDetails.totalSavings"
+              "apiField": "CapitalDetails.totalSavings"
             }
           ]
         }
@@ -216,7 +216,7 @@
               "apiField": "IncomeDetails.hasIncomeSupport"
             },
             {
-              "subHeading": "Give the total weekly income of:"
+              "subHeading": "Give the total weekly income of"
             },
             {
               "label": "Client",
@@ -250,15 +250,23 @@
               "apiField": "IncomeDetails.socialFundDeductions"
             },
             {
-              "subHeading": "Dependent children and other dependants:"
+              "subHeading": "Dependent children and other dependants"
             },
             {
               "label": "Aged 15 or under",
               "apiField": "IncomeDetails.dependantChildrenUnder15"
             },
             {
+              "label": "Amount",
+              "apiField": "IncomeDetails.deductionUnder15"
+            },
+            {
               "label": "Aged 16 or over",
               "apiField": "IncomeDetails.dependantChildrenOver16"
+            },
+            {
+              "label": "Amount",
+              "apiField": "IncomeDetails.deductionOver16"
             },
             {
               "label": "Less Total deductions",

--- a/server/services/config/crm5DisplayConfig.json
+++ b/server/services/config/crm5DisplayConfig.json
@@ -503,10 +503,7 @@
               "apiField": "AllCosts.AccruedCosts.Mileage.cost"
             },
             {
-              "subHeading": "Other disbursements"
-            },
-            {
-              "label": "Cost",
+              "label": "Other disbursements Cost",
               "apiField": "AllCosts.AccruedCosts.OtherDisbursement.cost"
             },
             {
@@ -583,15 +580,12 @@
               "apiField": "AllCosts.AnticipatedCosts.Mileage.cost"
             },
             {
-              "subHeading": "Other disbursements"
-            },
-            {
-              "label": "Cost",
-              "apiField": "AllCosts.AccruedCosts.OtherDisbursement.cost"
+              "label": "Other disbursements Cost",
+              "apiField": "AllCosts.AnticipatedCosts.OtherDisbursement.cost"
             },
             {
               "label": "Total Anticipated Costs",
-              "apiField": "AllCosts.AccruedCosts.TotalCost.cost"
+              "apiField": "AllCosts.AnticipatedCosts.TotalCost.cost"
             },
             {
               "label": "NEW LIMIT REQUEST",

--- a/server/services/config/crm5DisplayConfig.json
+++ b/server/services/config/crm5DisplayConfig.json
@@ -85,8 +85,7 @@
               "apiField": "CaseDetails.levelOfWork"
             },
             {
-              "label": "Class of work",
-              "apiField": null
+              "subHeading": "Class of work"
             },
             {
               "label": "",
@@ -136,8 +135,7 @@
               "apiField": "ClientDetails.maritalStatus"
             },
             {
-              "label": "Address",
-              "apiField": null
+              "subHeading": "Address"
             },
             {
               "label": "Client has no fixed abode",
@@ -145,27 +143,27 @@
             },
             {
               "label": "Address Line 1",
-              "apiField": "ClientDetails.addressLine1"
+              "apiField": "ClientDetails.address.addressLine1"
             },
             {
               "label": "Address Line 2",
-              "apiField": "ClientDetails.addressLine2"
+              "apiField": "ClientDetails.address.addressLine2"
             },
             {
               "label": "Address Line 3",
-              "apiField": "ClientDetails.addressLine3"
+              "apiField": "ClientDetails.address.addressLine3"
             },
             {
               "label": "Town",
-              "apiField": "ClientDetails.city"
+              "apiField": "ClientDetails.address.city"
             },
             {
               "label": "County",
-              "apiField": "ClientDetails.county"
+              "apiField": "ClientDetails.address.county"
             },
             {
               "label": "Postcode",
-              "apiField": "ClientDetails.postcode"
+              "apiField": "ClientDetails.address.postcode"
             }
           ]
         }
@@ -218,8 +216,7 @@
               "apiField": "IncomeDetails.hasIncomeSupport"
             },
             {
-              "label": "Give the total weekly income of:",
-              "apiField": null
+              "subHeading": "Give the total weekly income of:"
             },
             {
               "label": "Client",
@@ -234,8 +231,7 @@
               "apiField": "IncomeDetails.totalWeeklyIncome"
             },
             {
-              "label": "Allowable deductions",
-              "apiField": null
+              "subHeading": "Allowable deductions"
             },
             {
               "label": "Income tax",
@@ -254,8 +250,7 @@
               "apiField": "IncomeDetails.socialFundDeductions"
             },
             {
-              "label": "Dependent children and other dependants:",
-              "apiField": null
+              "subHeading": "Dependent children and other dependants:"
             },
             {
               "label": "Aged 15 or under",
@@ -368,8 +363,7 @@
           "title": "Solicitor's Declaration",
           "fields": [
             {
-              "label": "I confirm that my client has completed and signed the CRM2 Application for Advice and Assistance. I also confirm that the CRM2 Application shall be retained on file and submitted as per usual with the final bill or upon request by the Legal Aid Agency.",
-              "apiField": null
+              "subHeading": "I confirm that my client has completed and signed the CRM2 Application for Advice and Assistance. I also confirm that the CRM2 Application shall be retained on file and submitted as per usual with the final bill or upon request by the Legal Aid Agency."
             },
             {
               "label": "Name",
@@ -501,8 +495,7 @@
               "apiField": "AllCosts.AccruedCosts.Mileage.cost"
             },
             {
-              "label": "Other disbursements",
-              "apiField": null
+              "subHeading": "Other disbursements"
             },
             {
               "label": "Cost",
@@ -582,8 +575,7 @@
               "apiField": "AllCosts.AnticipatedCosts.Mileage.cost"
             },
             {
-              "label": "Other disbursements",
-              "apiField": null
+              "subHeading": "Other disbursements"
             },
             {
               "label": "Cost",
@@ -633,8 +625,7 @@
           "title": "Solicitor's Certification",
           "fields": [
             {
-              "label": "I certify that the information provided is correct.",
-              "apiField": null
+              "subHeading": "I certify that the information provided is correct."
             },
             {
               "label": "Name",

--- a/server/services/crmDisplayService.test.ts
+++ b/server/services/crmDisplayService.test.ts
@@ -124,7 +124,30 @@ describe('CRM Display Service', () => {
         sectionId: 'capital-details',
         subsections: [
           {
-            fields: [{ label: 'Is your client under 18 years old?', value: 'No' }],
+            fields: [
+              { label: 'Is your client under 18 years old?', value: 'No' },
+              {
+                label:
+                  "Does your client or partner (if living with client as couple) get Income Support, Income Based Job Seeker's Allowance, Income Related Employment and Support Allowance or Guarantee State Pension Credit?",
+                value: 'Yes',
+              },
+              {
+                label: 'How many dependants does your client have?',
+                value: 2,
+              },
+              {
+                label: 'Client',
+                value: 60000,
+              },
+              {
+                label: 'Partner',
+                value: 40000,
+              },
+              {
+                label: 'Total',
+                value: 100000,
+              },
+            ],
             title: 'Capital Details',
           },
         ],

--- a/server/services/crmDisplayService.test.ts
+++ b/server/services/crmDisplayService.test.ts
@@ -150,7 +150,7 @@ describe('CRM Display Service', () => {
 
       expect(result).toEqual({
         sectionId: 'clients-details',
-        subsections: [{ fields: [], title: "Client's Details" }],
+        subsections: [{ fields: [{ subHeading: 'Address' }], title: "Client's Details" }],
         title: "Client's Details",
       })
     })

--- a/server/views/pages/crmDetails.njk
+++ b/server/views/pages/crmDetails.njk
@@ -16,11 +16,16 @@
                 <div class="govuk-grid-column-two-thirds">
                     <div>
                         {% for subsection in section.subsections %}
-                            <div class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></div>
-                            <div class="govuk-form-group">
-                                <h2 class="govuk-heading-l">{{ subsection.title }}</h2>
-                                {% for field in subsection.fields %}
-                                    <div class="govuk-grid-row">
+                        <div class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></div>
+                        <div class="govuk-form-group">
+                            <h2 class="govuk-heading-l">{{ subsection.title }}</h2>
+                            {% for field in subsection.fields %}
+                                <div class="govuk-grid-row">
+                                    {% if field.subHeading %}
+                                        <div class="govuk-grid-column-one-half">
+                                            <h3 class="govuk-heading-m govuk-!-static-padding-top-5 govuk-!-static-margin-bottom-1">{{ field.subHeading }}</h3>
+                                        </div>
+                                    {% else %}
                                         <div class="govuk-grid-column-one-half">
                                             <div class="govuk-form-group">
                                                 <label class="govuk-label"><strong>{{ field.label }}</strong></label>
@@ -31,14 +36,14 @@
                                                 <span class="govuk-body">{{ field.value }}</span>
                                             </div>
                                         </div>
-                                    </div>
-                                {% endfor %}
-                            </div>
-                        {% endfor %}
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                            {% endfor %}
 
+                        </div>
                     </div>
                 </div>
-            </div>
 
         </main>
     </div>

--- a/server/views/pages/crmDetails.njk
+++ b/server/views/pages/crmDetails.njk
@@ -22,7 +22,7 @@
                             {% for field in subsection.fields %}
                                 <div class="govuk-grid-row">
                                     {% if field.subHeading %}
-                                        <div class="govuk-grid-column-one-half">
+                                        <div class="govuk-grid-column-full">
                                             <h3 class="govuk-heading-m govuk-!-static-padding-top-5 govuk-!-static-margin-bottom-1">{{ field.subHeading }}</h3>
                                         </div>
                                     {% else %}


### PR DESCRIPTION
**Changes made:**
- Added FieldOrSubHeading type for crmDisplay
- Added subHeadings to the display config file
- Fixed some issues in the config file
- Modified crmDisplay service to read subHeadings from config
- Modified crmDetails template to show subHeadings with initial styling