### PR TITLE
EMP-335:  Add CRM4 missing fields to display config

### DIFF
--- a/server/services/config/crm4DisplayConfig.json
+++ b/server/services/config/crm4DisplayConfig.json
@@ -78,11 +78,12 @@
             },
             {
               "label": "Rep order no. / case no.",
-              "apiField": "CaseDetails.ClientDetails.???"
+              "apiField": "CaseDetails.ClientDetails.repOrderNumber"
             },
             {
               "label": "Date of Rep order",
-              "apiField": "CaseDetails.ClientDetails.???"
+              "apiField": "CaseDetails.ClientDetails.repOrderDate",
+              "type": "date"
             },
             {
               "label": "UFN",
@@ -133,8 +134,7 @@
             },
             {
               "label": "Purpose of Next Hearing",
-              "apiField": "CaseDetails.ProceedingDetails.???",
-              "type": "date"
+              "apiField": "CaseDetails.ProceedingDetails.purposeOfHearing"
             }
           ]
         },


### PR DESCRIPTION
**Changes made:**
Modified crm4DisplayConfig.json with the correct apiField values for the following fields:-

- Rep order no.
- Date of Rep order
- Purpose of Next Hearing