### PR TITLE
EMP-356: Rename env var to EQ_API_URL

### DIFF
--- a/.github/deployments/deployment.yml
+++ b/.github/deployments/deployment.yml
@@ -37,12 +37,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: appsecret
-                key: EQ_API_SECRET    
-          - name: EQ_SEARCH_API_URL
-            valueFrom:
-              secretKeyRef:
-                name: appsecret
-                key: EQ_SEARCH_API_URL
+                key: EQ_API_SECRET
           - name: EQ_API_URL
             valueFrom:
               secretKeyRef:

--- a/server/config.ts
+++ b/server/config.ts
@@ -36,39 +36,39 @@ export interface ApiConfig {
 }
 
 export default {
-  buildNumber: get('BUILD_NUMBER', '1_0_0', { requireInProduction: false }),
-  productId: get('PRODUCT_ID', 'UNASSIGNED', { requireInProduction: false }),
-  gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', { requireInProduction: false }),
-  branchName: get('GIT_BRANCH', 'main', { requireInProduction: false }),
+  buildNumber: get('BUILD_NUMBER', '1_0_0'),
+  productId: get('PRODUCT_ID', 'UNASSIGNED'),
+  gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx'),
+  branchName: get('GIT_BRANCH', 'main'),
   production,
   https: production,
   staticResourceCacheDuration: '1h',
   redis: {
-    enabled: get('REDIS_ENABLED', 'false', { requireInProduction: false }),
-    host: get('REDIS_HOST', 'localhost', { requireInProduction: false }),
+    enabled: get('REDIS_ENABLED', 'false'),
+    host: get('REDIS_HOST', 'localhost'),
     port: parseInt(process.env.REDIS_PORT, 10) || 6379,
     password: process.env.REDIS_AUTH_TOKEN,
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
   },
   apis: {
     eqApi: {
-      url: get('EQ_SEARCH_API_URL', 'http://localhost:8089', { requireInProduction: false }),
+      url: get('EQ_API_URL', 'http://localhost:8089', requiredInProduction),
       timeout: {
         response: Number(get('EQ_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('EQ_API_TIMEOUT_DEADLINE', 10000)),
       },
       agent: new AgentConfig(Number(get('EQ_API_TIMEOUT_RESPONSE', 10000))),
       headers: {
-        clientId: get('EQ_API_CLIENT_ID', 'xxx', { requireInProduction: false }),
-        secret: get('EQ_API_SECRET', 'xxx', { requireInProduction: false }),
+        clientId: get('EQ_API_CLIENT_ID', 'xxx', requiredInProduction),
+        secret: get('EQ_API_SECRET', 'xxx', requiredInProduction),
       },
     },
   },
   session: {
-    secret: get('SESSION_SECRET', 'app-insecure-default-session', { requireInProduction: false }),
+    secret: get('SESSION_SECRET', 'app-insecure-default-session'),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
   },
-  domain: get('INGRESS_URL', 'http://localhost:3000', { requireInProduction: false }),
+  domain: get('INGRESS_URL', 'http://localhost:3000'),
   // The fallback should be empty. It will become when all environments will be setup.
   environmentName: get('ENVIRONMENT_NAME', 'Local'),
 }


### PR DESCRIPTION
**Changes made:**

- Removed EQ_SEARCH_API_URL from deployment.yml
- Replaced EQ_SEARCH_API_URL with EQ_API_URL in config.ts
- Cleaned up config.ts