### PR TITLE
EMP-388: Send profileAcceptedTypes header to BE API

### DIFF
--- a/.github/deployments/deployment.yml
+++ b/.github/deployments/deployment.yml
@@ -68,11 +68,6 @@ spec:
               secretKeyRef:
                 name: elasticache-redis
                 key: auth_token
-          - name: SSO_ENABLED
-            valueFrom:
-              secretKeyRef:
-                name: appsecret
-                key: SSO_ENABLED
           - name: CLOUD_INSTANCE
             valueFrom:
               secretKeyRef:
@@ -108,4 +103,8 @@ spec:
               secretKeyRef:
                 name: appsecret
                 key: EXPRESS_SESSION_SECRET
-          
+          - name: ALLOWED_USER_PROFILE_GROUPS
+            valueFrom:
+              secretKeyRef:
+                name: appsecret
+                key: ALLOWED_USER_PROFILE_GROUPS

--- a/server/@types/searchEform/index.d.ts
+++ b/server/@types/searchEform/index.d.ts
@@ -24,6 +24,7 @@ type SearchRequest = {
   supplierAccountNumber?: string
   pageSize: number
   page: number
+  profileAcceptedTypes: string
 }
 
 type SearchPaging = {

--- a/server/config.ts
+++ b/server/config.ts
@@ -44,11 +44,11 @@ export default {
   https: production,
   staticResourceCacheDuration: '1h',
   sso: {
-    enabled: get('SSO_ENABLED', 'false', requiredInProduction) === 'true',
     cloudInstance: get('CLOUD_INSTANCE', 'https://login.microsoftonline.com/', requiredInProduction),
     clientId: get('CLIENT_ID', 'xxx', requiredInProduction),
     clientSecret: get('CLIENT_SECRET', 'xxx', requiredInProduction),
     tenantId: get('TENANT_ID', 'xxx', requiredInProduction),
+    allowedUserProfileGroups: get('ALLOWED_USER_PROFILE_GROUPS', '{}', requiredInProduction),
   },
   redis: {
     enabled: get('REDIS_ENABLED', 'false', requiredInProduction) === 'true',

--- a/server/config.ts
+++ b/server/config.ts
@@ -48,7 +48,7 @@ export default {
     clientId: get('CLIENT_ID', 'xxx', requiredInProduction),
     clientSecret: get('CLIENT_SECRET', 'xxx', requiredInProduction),
     tenantId: get('TENANT_ID', 'xxx', requiredInProduction),
-    allowedUserProfileGroups: get('ALLOWED_USER_PROFILE_GROUPS', '{}', requiredInProduction),
+    allowedUserProfileGroups: get('ALLOWED_USER_PROFILE_GROUPS', '', requiredInProduction),
   },
   redis: {
     enabled: get('REDIS_ENABLED', 'false', requiredInProduction) === 'true',

--- a/server/controllers/crm/crm14Controller.test.ts
+++ b/server/controllers/crm/crm14Controller.test.ts
@@ -6,6 +6,9 @@ import Crm14Controller from './crm14Controller'
 
 jest.mock('../../services/crmApiService')
 jest.mock('../../services/crmDisplayService')
+jest.mock('../../utils/userProfileGroups', () => {
+  return jest.fn().mockReturnValue('1,4,5,6')
+})
 
 describe('CRM14 Controller', () => {
   let mockCrmApiService: jest.Mocked<CrmApiService<Crm14Response>>

--- a/server/controllers/crm/crm14Controller.ts
+++ b/server/controllers/crm/crm14Controller.ts
@@ -10,7 +10,7 @@ export default class Crm14Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm14Response = await this.crm14Service.getCrm(usn)
+      const crm14Response = await this.crm14Service.getCrm(usn, '1,4,5,6')
 
       const currentUrl = `/crm14/${usn}/${sectionId || 'legal-rep-use'}`
       const backUrl = manageBackLink(req, currentUrl)

--- a/server/controllers/crm/crm14Controller.ts
+++ b/server/controllers/crm/crm14Controller.ts
@@ -2,6 +2,7 @@ import { type Request, RequestHandler, type Response } from 'express'
 import { Crm14Response } from '@crm14'
 import CrmApiService from '../../services/crmApiService'
 import manageBackLink from '../../utils/crmBackLink'
+import getProfileAcceptedTypes from '../../utils/userProfileGroups'
 
 export default class Crm14Controller {
   constructor(private readonly crm14Service: CrmApiService<Crm14Response>) {}
@@ -10,7 +11,7 @@ export default class Crm14Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm14Response = await this.crm14Service.getCrm(usn, '1,4,5,6')
+      const crm14Response = await this.crm14Service.getCrm(usn, getProfileAcceptedTypes(res))
 
       const currentUrl = `/crm14/${usn}/${sectionId || 'legal-rep-use'}`
       const backUrl = manageBackLink(req, currentUrl)

--- a/server/controllers/crm/crm4Controller.test.ts
+++ b/server/controllers/crm/crm4Controller.test.ts
@@ -8,6 +8,9 @@ import CrmDisplayService from '../../services/crmDisplayService'
 
 jest.mock('../../services/crmApiService')
 jest.mock('../../services/crmDisplayService')
+jest.mock('../../utils/userProfileGroups', () => {
+  return jest.fn().mockReturnValue('1,4,5,6')
+})
 
 describe('CRM4 Controller', () => {
   let mockCrmApiService: jest.Mocked<CrmApiService<Crm4Response>>

--- a/server/controllers/crm/crm4Controller.ts
+++ b/server/controllers/crm/crm4Controller.ts
@@ -3,6 +3,7 @@ import { Crm4Response } from '@crm4'
 import CrmApiService from '../../services/crmApiService'
 import CrmDisplayService from '../../services/crmDisplayService'
 import manageBackLink from '../../utils/crmBackLink'
+import getProfileAcceptedTypes from '../../utils/userProfileGroups'
 
 export default class Crm4Controller {
   constructor(
@@ -14,7 +15,7 @@ export default class Crm4Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm4Response = await this.crm4Service.getCrm(usn, '1,4,5,6')
+      const crm4Response = await this.crm4Service.getCrm(usn, getProfileAcceptedTypes(res))
       const navigation = this.crmDisplayService.getCrmNavigation('crm4', usn, sectionId, crm4Response)
       const section = this.crmDisplayService.getCrmSection('crm4', sectionId, crm4Response)
 

--- a/server/controllers/crm/crm4Controller.ts
+++ b/server/controllers/crm/crm4Controller.ts
@@ -14,7 +14,7 @@ export default class Crm4Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm4Response = await this.crm4Service.getCrm(usn)
+      const crm4Response = await this.crm4Service.getCrm(usn, '1,4,5,6')
       const navigation = this.crmDisplayService.getCrmNavigation('crm4', usn, sectionId, crm4Response)
       const section = this.crmDisplayService.getCrmSection('crm4', sectionId, crm4Response)
 

--- a/server/controllers/crm/crm5Controller.test.ts
+++ b/server/controllers/crm/crm5Controller.test.ts
@@ -8,6 +8,9 @@ import CrmDisplayService from '../../services/crmDisplayService'
 
 jest.mock('../../services/crmApiService')
 jest.mock('../../services/crmDisplayService')
+jest.mock('../../utils/userProfileGroups', () => {
+  return jest.fn().mockReturnValue('1,4,5,6')
+})
 
 describe('CRM5 Controller', () => {
   let mockCrmApiService: jest.Mocked<CrmApiService<Crm5Response>>

--- a/server/controllers/crm/crm5Controller.ts
+++ b/server/controllers/crm/crm5Controller.ts
@@ -3,6 +3,7 @@ import { Crm5Response } from '@crm5'
 import CrmApiService from '../../services/crmApiService'
 import CrmDisplayService from '../../services/crmDisplayService'
 import manageBackLink from '../../utils/crmBackLink'
+import getProfileAcceptedTypes from '../../utils/userProfileGroups'
 
 export default class Crm5Controller {
   constructor(
@@ -14,7 +15,7 @@ export default class Crm5Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm5Response = await this.crm5Service.getCrm(usn, '1,4,5,6')
+      const crm5Response = await this.crm5Service.getCrm(usn, getProfileAcceptedTypes(res))
       const navigation = this.crmDisplayService.getCrmNavigation('crm5', usn, sectionId, crm5Response)
       const section = this.crmDisplayService.getCrmSection('crm5', sectionId, crm5Response)
 

--- a/server/controllers/crm/crm5Controller.ts
+++ b/server/controllers/crm/crm5Controller.ts
@@ -14,7 +14,7 @@ export default class Crm5Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm5Response = await this.crm5Service.getCrm(usn)
+      const crm5Response = await this.crm5Service.getCrm(usn, '1,4,5,6')
       const navigation = this.crmDisplayService.getCrmNavigation('crm5', usn, sectionId, crm5Response)
       const section = this.crmDisplayService.getCrmSection('crm5', sectionId, crm5Response)
 

--- a/server/controllers/crm/crm7Controller.test.ts
+++ b/server/controllers/crm/crm7Controller.test.ts
@@ -8,6 +8,9 @@ import Crm7Controller from './crm7Controller'
 
 jest.mock('../../services/crmApiService')
 jest.mock('../../services/crmDisplayService')
+jest.mock('../../utils/userProfileGroups', () => {
+  return jest.fn().mockReturnValue('1,4,5,6')
+})
 
 describe('CRM7 Controller', () => {
   let mockCrmApiService: jest.Mocked<CrmApiService<Crm7Response>>

--- a/server/controllers/crm/crm7Controller.ts
+++ b/server/controllers/crm/crm7Controller.ts
@@ -3,6 +3,7 @@ import { Crm7Response } from '@crm7'
 import CrmApiService from '../../services/crmApiService'
 import CrmDisplayService from '../../services/crmDisplayService'
 import manageBackLink from '../../utils/crmBackLink'
+import getProfileAcceptedTypes from '../../utils/userProfileGroups'
 
 export default class Crm7Controller {
   constructor(
@@ -14,7 +15,7 @@ export default class Crm7Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm7Response = await this.crm7Service.getCrm(usn, '1,4,5,6')
+      const crm7Response = await this.crm7Service.getCrm(usn, getProfileAcceptedTypes(res))
       const navigation = this.crmDisplayService.getCrmNavigation('crm7', usn, sectionId, crm7Response)
       const section = this.crmDisplayService.getCrmSection('crm7', sectionId, crm7Response)
 

--- a/server/controllers/crm/crm7Controller.ts
+++ b/server/controllers/crm/crm7Controller.ts
@@ -14,7 +14,7 @@ export default class Crm7Controller {
     return async (req: Request, res: Response): Promise<void> => {
       const usn = Number(req.params.usn)
       const { sectionId } = req.params
-      const crm7Response = await this.crm7Service.getCrm(usn)
+      const crm7Response = await this.crm7Service.getCrm(usn, '1,4,5,6')
       const navigation = this.crmDisplayService.getCrmNavigation('crm7', usn, sectionId, crm7Response)
       const section = this.crmDisplayService.getCrmSection('crm7', sectionId, crm7Response)
 

--- a/server/controllers/searchEformController.test.ts
+++ b/server/controllers/searchEformController.test.ts
@@ -106,6 +106,7 @@ describe('Search Eform Controller', () => {
       usn: '123456789',
       page: 0,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
   })
 
@@ -237,6 +238,7 @@ describe('Search Eform Controller', () => {
       usn: '8888888',
       page: 0,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
   })
 

--- a/server/controllers/searchEformController.test.ts
+++ b/server/controllers/searchEformController.test.ts
@@ -6,6 +6,9 @@ import SearchEformController from './searchEformController'
 import SearchEformService from '../services/searchEformService'
 
 jest.mock('../services/searchEformService')
+jest.mock('../utils/userProfileGroups', () => {
+  return jest.fn().mockReturnValue('1,4,5,6')
+})
 
 describe('Search Eform Controller', () => {
   let mockSearchEformService: jest.Mocked<SearchEformService>

--- a/server/controllers/searchEformController.ts
+++ b/server/controllers/searchEformController.ts
@@ -4,6 +4,7 @@ import SearchEformService from '../services/searchEformService'
 import validateSearchQuery, { SearchValidationErrors } from '../utils/searchEformValidation'
 import getPagination from '../utils/pagination'
 import { buildQueryString } from '../utils/utils'
+import getProfileAcceptedTypes from '../utils/userProfileGroups'
 
 const SEARCH_PAGE_SIZE = 10
 
@@ -40,7 +41,7 @@ export default class SearchEformController {
           res.render(VIEW_PATH, { results: [], errors: validationErrors, formValues: queryParams })
         } else {
           // perform search
-          const searchRequest = buildSearchRequest(queryParams)
+          const searchRequest = buildSearchRequest(queryParams, getProfileAcceptedTypes(res))
           const searchResponse = await this.searchEformService.search(searchRequest)
 
           if (searchResponse.error) {
@@ -116,7 +117,7 @@ const getErrorMessage = (errorStatus: number): string => {
   }
 }
 
-const buildSearchRequest = (queryParams: Record<string, string>): SearchRequest => {
+const buildSearchRequest = (queryParams: Record<string, string>, profileAcceptedTypes: string): SearchRequest => {
   return {
     usn: undefinedIfEmpty(queryParams.usn),
     type: undefinedIfEmpty(queryParams.type) && Number(queryParams.type),
@@ -127,7 +128,7 @@ const buildSearchRequest = (queryParams: Record<string, string>): SearchRequest 
     endDate: undefinedIfEmpty(queryParams.endDate),
     page: Number(queryParams.page) - 1, // search api page number starts from 0
     pageSize: SEARCH_PAGE_SIZE,
-    profileAcceptedTypes: '1,4,5,6',
+    profileAcceptedTypes,
   }
 }
 

--- a/server/controllers/searchEformController.ts
+++ b/server/controllers/searchEformController.ts
@@ -50,7 +50,7 @@ export default class SearchEformController {
           } else {
             // render with search results
             const { results, paging } = searchResponse
-            const baseUrl = `/search-eform?${buildQueryString(searchRequest)}&`
+            const baseUrl = `/search-eform?${buildQueryString(queryParams)}&`
             // Reset session history when a new search is performed
             req.session.history = []
             // Store search results and form values in session
@@ -127,6 +127,7 @@ const buildSearchRequest = (queryParams: Record<string, string>): SearchRequest 
     endDate: undefinedIfEmpty(queryParams.endDate),
     page: Number(queryParams.page) - 1, // search api page number starts from 0
     pageSize: SEARCH_PAGE_SIZE,
+    profileAcceptedTypes: '1,4,5,6',
   }
 }
 

--- a/server/data/api/crmApiClient.test.ts
+++ b/server/data/api/crmApiClient.test.ts
@@ -55,7 +55,7 @@ describe('CRM Api Client', () => {
       .matchHeader('authorization', 'Bearer no_auth')
       .reply(200, crm5Response)
 
-    const result = await crm5ApiClient.getCrm(1234567)
+    const result = await crm5ApiClient.getCrm(1234567, '1,4,5,6')
 
     expect(result).toEqual(crm5Response)
   })

--- a/server/data/api/crmApiClient.ts
+++ b/server/data/api/crmApiClient.ts
@@ -14,10 +14,13 @@ export default class CrmApiClient<T extends CrmResponse> {
     return new RestClient(name, config.apis.eqApi, token)
   }
 
-  async getCrm(usn: number): Promise<T> {
+  async getCrm(usn: number, profileAcceptedTypes: string): Promise<T> {
     return CrmApiClient.restClient('CRM API client', 'no_auth').get<T>({
       path: `/api/internal/v1/equinity/${this.crmApiPath}/${usn}`,
-      headers: this.headers,
+      headers: {
+        ...this.headers,
+        profileAcceptedTypes,
+      },
     })
   }
 }

--- a/server/data/api/searchApiClient.test.ts
+++ b/server/data/api/searchApiClient.test.ts
@@ -56,7 +56,12 @@ describe('EQ Search Api Client', () => {
       .matchHeader('authorization', 'Bearer no_auth')
       .reply(200, searchResponse)
 
-    const result = await searchApiClient.search({ usn: '1234567', page: 0, pageSize: 10 })
+    const result = await searchApiClient.search({
+      usn: '1234567',
+      page: 0,
+      pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
+    })
 
     expect(result).toEqual(searchResponse)
   })
@@ -90,6 +95,7 @@ describe('EQ Search Api Client', () => {
       clientName: 'Jane Doe',
       page: 0,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
 
     expect(result).toEqual(searchResponse)
@@ -141,6 +147,7 @@ describe('EQ Search Api Client', () => {
       supplierAccountNumber: '1234AB',
       page: 0,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
 
     expect(result).toEqual(searchResponse)

--- a/server/data/api/searchApiClient.ts
+++ b/server/data/api/searchApiClient.ts
@@ -13,7 +13,10 @@ export default class SearchApiClient {
   async search(searchRequest: SearchRequest): Promise<SearchResponse> {
     return SearchApiClient.restClient('no_auth').get<SearchResponse>({
       path: '/api/internal/v1/equinity/search/',
-      headers: this.headers,
+      headers: {
+        ...this.headers,
+        profileAcceptedTypes: searchRequest.profileAcceptedTypes,
+      },
       query: {
         usn: searchRequest.usn,
         type: searchRequest.type,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -3,15 +3,11 @@ import createError from 'http-errors'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import authProvider from '../auth/authProvider'
 import { REDIRECT_URI, POST_LOGOUT_REDIRECT_URI } from '../auth/authConfig'
-import config from '../config'
 
 export default function routes(): Router {
   const router = Router()
 
   router.use((req: Request, res: Response, next: NextFunction): void => {
-    if (!config.sso.enabled) {
-      return next(createError(404, 'Not found'))
-    }
     return next()
   })
 

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -13,9 +13,6 @@ import CrmDisplayService from '../services/crmDisplayService'
 jest.mock('../services/crmApiService')
 jest.mock('../services/searchEformService')
 jest.mock('../services/crmDisplayService')
-// jest.mock('../utils/userProfileGroups', () => {
-//   return jest.fn().mockReturnValue('1,4,5,6')
-// })
 
 let app: Express
 

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -13,6 +13,9 @@ import CrmDisplayService from '../services/crmDisplayService'
 jest.mock('../services/crmApiService')
 jest.mock('../services/searchEformService')
 jest.mock('../services/crmDisplayService')
+// jest.mock('../utils/userProfileGroups', () => {
+//   return jest.fn().mockReturnValue('1,4,5,6')
+// })
 
 let app: Express
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,7 +2,6 @@ import { type NextFunction, type Request, type RequestHandler, type Response, Ro
 
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import { Controllers } from '../controllers'
-import config from '../config'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes({
@@ -17,10 +16,6 @@ export default function routes({
 
   router.use((req: Request, res: Response, next: NextFunction): void => {
     // custom middleware to check auth state
-    if (!config.sso.enabled) {
-      return next()
-    }
-
     if (!req.session.isAuthenticated) {
       return res.redirect('/auth/signin') // redirect to sign-in route
     }
@@ -28,6 +23,7 @@ export default function routes({
     if (req.session.isAuthenticated) {
       res.locals.username = req.session.account?.name
       res.locals.isAuthenticated = req.session.isAuthenticated
+      res.locals.ssoUserGroups = req.session.account?.idTokenClaims?.groups
     }
     return next()
   })

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -29,6 +29,11 @@ function appSetup(services: Services, production: boolean): Express {
   app.use(cookieSession({ keys: [''] }))
   app.use((req, res, next) => {
     req.flash = flashProvider
+    // set user as authenticated
+    req.session.isAuthenticated = true
+    req.session.account = {}
+    req.session.account.name = 'Jane Doe'
+    req.session.account.idTokenClaims = { groups: [] }
     next()
   })
   app.use(express.json())

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -33,7 +33,6 @@ function appSetup(services: Services, production: boolean): Express {
     req.session.isAuthenticated = true
     req.session.account = {}
     req.session.account.name = 'Jane Doe'
-    req.session.account.idTokenClaims = { groups: [] }
     next()
   })
   app.use(express.json())

--- a/server/services/crmApiService.test.ts
+++ b/server/services/crmApiService.test.ts
@@ -18,10 +18,10 @@ describe('CRM API Service', () => {
 
     const crm5Service = new CrmApiService(mockCrm5ApiClient)
 
-    const result = await crm5Service.getCrm(1234567)
+    const result = await crm5Service.getCrm(1234567, '1,4,5,6')
 
     expect(result).toEqual(expectedResponse)
-    expect(mockCrm5ApiClient.getCrm).toHaveBeenCalledWith(1234567)
+    expect(mockCrm5ApiClient.getCrm).toHaveBeenCalledWith(1234567, '1,4,5,6')
   })
 })
 

--- a/server/services/crmApiService.ts
+++ b/server/services/crmApiService.ts
@@ -4,7 +4,7 @@ import CrmApiClient from '../data/api/crmApiClient'
 export default class CrmApiService<T extends CrmResponse> {
   constructor(private readonly crmApiClient: CrmApiClient<T>) {}
 
-  async getCrm(usn: number): Promise<T> {
-    return this.crmApiClient.getCrm(usn)
+  async getCrm(usn: number, profileAcceptedTypes: string): Promise<T> {
+    return this.crmApiClient.getCrm(usn, profileAcceptedTypes)
   }
 }

--- a/server/services/searchEformService.test.ts
+++ b/server/services/searchEformService.test.ts
@@ -40,7 +40,12 @@ describe('Search Eform Service', () => {
 
     const searchEformService = new SearchEformService(mockSearchApiClient)
 
-    const result = await searchEformService.search({ usn: '1234567', page: 0, pageSize: 10 })
+    const result = await searchEformService.search({
+      usn: '1234567',
+      page: 0,
+      pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
+    })
 
     expect(result).toEqual({
       results: [
@@ -70,6 +75,7 @@ describe('Search Eform Service', () => {
       usn: '1234567',
       page: 0,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
   })
 
@@ -86,7 +92,12 @@ describe('Search Eform Service', () => {
 
     const searchEformService = new SearchEformService(mockSearchApiClient)
 
-    const result = await searchEformService.search({ usn: '1234567', page: 0, pageSize: 10 })
+    const result = await searchEformService.search({
+      usn: '1234567',
+      page: 0,
+      pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
+    })
 
     expect(result).toEqual({
       error: {
@@ -99,6 +110,7 @@ describe('Search Eform Service', () => {
       usn: '1234567',
       page: 0,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
   })
 
@@ -118,7 +130,12 @@ describe('Search Eform Service', () => {
 
     const searchEformService = new SearchEformService(mockSearchApiClient)
 
-    const result = await searchEformService.search({ usn: '1234567', page: 100, pageSize: 10 })
+    const result = await searchEformService.search({
+      usn: '1234567',
+      page: 100,
+      pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
+    })
     expect(result).toEqual({
       error: {
         message: 'No search results found',
@@ -130,6 +147,7 @@ describe('Search Eform Service', () => {
       usn: '1234567',
       page: 100,
       pageSize: 10,
+      profileAcceptedTypes: '1,4,5,6',
     })
   })
 })

--- a/server/utils/userProfileGroups.test.ts
+++ b/server/utils/userProfileGroups.test.ts
@@ -66,14 +66,4 @@ describe('getProfileAcceptedTypes()', () => {
 
     expect(result).toEqual('')
   })
-
-  it('should return empty string if ssoUserGroups are unavailable', () => {
-    response.locals = {
-      user: { token: '', authSource: '' },
-    }
-
-    const result = getProfileAcceptedTypes(response)
-
-    expect(result).toEqual('')
-  })
 })

--- a/server/utils/userProfileGroups.test.ts
+++ b/server/utils/userProfileGroups.test.ts
@@ -1,0 +1,79 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import type { Response } from 'express'
+import getProfileAcceptedTypes from './userProfileGroups'
+
+jest.mock('../config', () => {
+  return {
+    sso: {
+      allowedUserProfileGroups: `{"36c86b9e-be2f-4f73-8bf7-ea654dea0165":1, "1dd31ec8-f384-4661-bd3f-34aa2588706e":4, "87bfe474-f53e-4641-b992-fff11346782f":5, "2248a7a9-6cd2-4330-80fd-cb916edd445e":6}`,
+    },
+  }
+})
+
+describe('getProfileAcceptedTypes()', () => {
+  let response: DeepMocked<Response>
+
+  beforeEach(() => {
+    response = createMock<Response>({})
+  })
+
+  it('should return profile accepted types', () => {
+    response.locals = {
+      user: { token: '', authSource: '' },
+      ssoUserGroups: [
+        '36c86b9e-be2f-4f73-8bf7-ea654dea0165', // type 1
+        '87bfe474-f53e-4641-b992-fff11346782f', // type 5
+        'be12a2da-8c3d-4681-8e50-3290c9d2d925', // not allowed
+        '6f3c64a9-8ab4-4e2a-afe8-f3abb72a9375', // not allowed
+      ],
+    }
+
+    const result = getProfileAcceptedTypes(response)
+
+    expect(result).toEqual('1,5')
+  })
+
+  it('should return empty string if allowed groups not found', () => {
+    response.locals = {
+      user: { token: '', authSource: '' },
+      ssoUserGroups: [
+        'be12a2da-8c3d-4681-8e50-3290c9d2d925', // not allowed
+        '6f3c64a9-8ab4-4e2a-afe8-f3abb72a9375', // not allowed
+      ],
+    }
+
+    const result = getProfileAcceptedTypes(response)
+
+    expect(result).toEqual('')
+  })
+
+  it('should return empty string if ssoUserGroups are unavailable', () => {
+    response.locals = {
+      user: { token: '', authSource: '' },
+    }
+
+    const result = getProfileAcceptedTypes(response)
+
+    expect(result).toEqual('')
+  })
+
+  it('should return empty string if ssoUserGroups are unavailable', () => {
+    response.locals = {
+      user: { token: '', authSource: '' },
+    }
+
+    const result = getProfileAcceptedTypes(response)
+
+    expect(result).toEqual('')
+  })
+
+  it('should return empty string if ssoUserGroups are unavailable', () => {
+    response.locals = {
+      user: { token: '', authSource: '' },
+    }
+
+    const result = getProfileAcceptedTypes(response)
+
+    expect(result).toEqual('')
+  })
+})

--- a/server/utils/userProfileGroups.test.ts
+++ b/server/utils/userProfileGroups.test.ts
@@ -5,7 +5,8 @@ import getProfileAcceptedTypes from './userProfileGroups'
 jest.mock('../config', () => {
   return {
     sso: {
-      allowedUserProfileGroups: `{"36c86b9e-be2f-4f73-8bf7-ea654dea0165":1, "1dd31ec8-f384-4661-bd3f-34aa2588706e":4, "87bfe474-f53e-4641-b992-fff11346782f":5, "2248a7a9-6cd2-4330-80fd-cb916edd445e":6}`,
+      allowedUserProfileGroups:
+        '36c86b9e-be2f-4f73-8bf7-ea654dea0165:1,1dd31ec8-f384-4661-bd3f-34aa2588706e:4,87bfe474-f53e-4641-b992-fff11346782f:5,2248a7a9-6cd2-4330-80fd-cb916edd445e:6',
     },
   }
 })

--- a/server/utils/userProfileGroups.test.ts
+++ b/server/utils/userProfileGroups.test.ts
@@ -57,14 +57,4 @@ describe('getProfileAcceptedTypes()', () => {
 
     expect(result).toEqual('')
   })
-
-  it('should return empty string if ssoUserGroups are unavailable', () => {
-    response.locals = {
-      user: { token: '', authSource: '' },
-    }
-
-    const result = getProfileAcceptedTypes(response)
-
-    expect(result).toEqual('')
-  })
 })

--- a/server/utils/userProfileGroups.ts
+++ b/server/utils/userProfileGroups.ts
@@ -1,0 +1,27 @@
+import type { Response } from 'express'
+
+import config from '../config'
+import logger from '../../logger'
+
+function getProfileAcceptedTypes(res: Response): string {
+  let allowedUserProfileGroups
+  try {
+    allowedUserProfileGroups = JSON.parse(config.sso.allowedUserProfileGroups)
+  } catch (error) {
+    logger.error('Unable to parse "config.sso.allowedUserProfileGroups" as JSON', error)
+    return ''
+  }
+
+  const ssoUserGroups = res.locals.ssoUserGroups || []
+  return Object.keys(allowedUserProfileGroups)
+    .map(groupId => {
+      if (ssoUserGroups.includes(groupId)) {
+        return allowedUserProfileGroups[groupId]
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',')
+}
+
+export default getProfileAcceptedTypes

--- a/server/utils/userProfileGroups.ts
+++ b/server/utils/userProfileGroups.ts
@@ -3,14 +3,14 @@ import type { Response } from 'express'
 import config from '../config'
 
 function getProfileAcceptedTypes(res: Response): string {
+  const ssoUserGroups = res.locals.ssoUserGroups || []
   const allowedUserProfileGroups = config.sso.allowedUserProfileGroups.split(',')
 
-  const ssoUserGroups = res.locals.ssoUserGroups || []
   return allowedUserProfileGroups
     .map(group => {
-      const parts = group.split(':')
-      if (ssoUserGroups.includes(parts[0])) {
-        return parts[1]
+      const [groupId, crmTypeId] = group.split(':')
+      if (ssoUserGroups.includes(groupId)) {
+        return crmTypeId
       }
       return null
     })

--- a/server/utils/userProfileGroups.ts
+++ b/server/utils/userProfileGroups.ts
@@ -1,22 +1,16 @@
 import type { Response } from 'express'
 
 import config from '../config'
-import logger from '../../logger'
 
 function getProfileAcceptedTypes(res: Response): string {
-  let allowedUserProfileGroups
-  try {
-    allowedUserProfileGroups = JSON.parse(config.sso.allowedUserProfileGroups)
-  } catch (error) {
-    logger.error('Unable to parse "config.sso.allowedUserProfileGroups" as JSON', error)
-    return ''
-  }
+  const allowedUserProfileGroups = config.sso.allowedUserProfileGroups.split(',')
 
   const ssoUserGroups = res.locals.ssoUserGroups || []
-  return Object.keys(allowedUserProfileGroups)
-    .map(groupId => {
-      if (ssoUserGroups.includes(groupId)) {
-        return allowedUserProfileGroups[groupId]
+  return allowedUserProfileGroups
+    .map(group => {
+      const parts = group.split(':')
+      if (ssoUserGroups.includes(parts[0])) {
+        return parts[1]
       }
       return null
     })


### PR DESCRIPTION
**Changes made:**

- Removed SSO_ENABLED env variable
- Added ALLOWED_USER_PROFILE_GROUPS env variable
- Added sso.allowedUserProfileGroups to config
- Modified all controllers to send profileAcceptedTypes request header
- Store ssoUserGroups in response.locals
- Added getProfileAcceptedTypes to determine profileAcceptedTypes against user's groups