### PR TITLE
EMP-438: Restrict Report UI return 403 Forbidden error

### DIFF
--- a/server/controllers/generateReportController.test.ts
+++ b/server/controllers/generateReportController.test.ts
@@ -48,15 +48,6 @@ describe('GenerateReportController', () => {
       expect(request.session.successMessage).toBeNull()
       expect(request.session.downloadUrl).toBeNull()
     })
-
-    it('should throw error if reporting is not allowed', async () => {
-      mockIsReportingAllowed.mockReturnValue(false) // reporting not allowed
-
-      const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.show()
-
-      await expect(requestHandler(request, response, next)).rejects.toThrow(new Error('Forbidden'))
-    })
   })
 
   describe('submit()', () => {
@@ -78,15 +69,6 @@ describe('GenerateReportController', () => {
       expect(request.session.successMessage).toEqual('The report is being downloaded.')
       expect(request.session.downloadUrl).toEqual('/generate-report/download?startDate=2023-03-01&endDate=2023-03-30')
       expect(request.session.formValues).toEqual({ crmType: 'crm4', endDate: '2023-03-30', startDate: '2023-03-01' })
-    })
-
-    it('should throw error if reporting is not allowed', async () => {
-      mockIsReportingAllowed.mockReturnValue(false) // reporting not allowed
-
-      const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.submit()
-
-      await expect(requestHandler(request, response, next)).rejects.toThrow(new Error('Forbidden'))
     })
 
     it('should render generate report page with field errors', async () => {
@@ -123,6 +105,44 @@ describe('GenerateReportController', () => {
         },
       })
     })
+  })
+
+  describe('download()', () => {
+    it('should handle /generate-report/download route and generate the report', async () => {
+      const crmReportResponse = getCrmReportResponse()
+      mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
+
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.download()
+
+      request.query = {
+        startDate: '2023-03-01',
+        endDate: '2023-03-30',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename=crmReport.csv')
+      expect(response.send).toHaveBeenCalledWith(crmReportResponse.text)
+      expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
+    })
+
+    it('should handle errors during /generate-report/download route', async () => {
+      const error = new Error('Error generating report')
+      mockGenerateReportService.getCrmReport.mockRejectedValue(error)
+
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.download()
+
+      request.query = {
+        startDate: '2023-03-01',
+        endDate: '2023-03-30',
+      }
+
+      await expect(requestHandler(request, response, next)).rejects.toThrow('Error generating report')
+
+      expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
+    })
 
     it.each([
       ['Not authorised to generate report', 401],
@@ -141,9 +161,8 @@ describe('GenerateReportController', () => {
       mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
 
       const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.submit()
-      request.body = {
-        crmType: 'crm4',
+      const requestHandler = generateReportController.download()
+      request.query = {
         startDate: '2023-03-01',
         endDate: '2023-03-30',
       }
@@ -167,53 +186,6 @@ describe('GenerateReportController', () => {
           endDate: '2023-03-30',
         },
       })
-    })
-  })
-
-  describe('download()', () => {
-    it('should handle /generate-report/download route and generate the report', async () => {
-      const crmReportResponse = getCrmReportResponse()
-      mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
-
-      const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.download()
-
-      request.query = {
-        startDate: '2023-03-01',
-        endDate: '2023-03-30',
-      }
-
-      await requestHandler(request, response, next)
-
-      expect(response.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename=crmReport.csv')
-      expect(response.send).toHaveBeenCalledWith(crmReportResponse.text)
-      expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
-    })
-
-    it('should throw error if reporting is not allowed', async () => {
-      mockIsReportingAllowed.mockReturnValue(false) // reporting not allowed
-
-      const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.download()
-
-      await expect(requestHandler(request, response, next)).rejects.toThrow(new Error('Forbidden'))
-    })
-
-    it('should handle errors during /generate-report/download route', async () => {
-      const error = new Error('Error generating report')
-      mockGenerateReportService.getCrmReport.mockRejectedValue(error)
-
-      const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.download()
-
-      request.query = {
-        startDate: '2023-03-01',
-        endDate: '2023-03-30',
-      }
-
-      await expect(requestHandler(request, response, next)).rejects.toThrow('Error generating report')
-
-      expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
     })
   })
 })

--- a/server/controllers/generateReportController.test.ts
+++ b/server/controllers/generateReportController.test.ts
@@ -3,15 +3,14 @@ import type { NextFunction, Request, Response } from 'express'
 import { CrmReportResponse } from '@crmReport'
 import GenerateReportService from '../services/generateReportService'
 import GenerateReportController from './generateReportController'
+import { getProfileAcceptedTypes, isReportingAllowed } from '../utils/userProfileGroups'
 
 jest.mock('../services/generateReportService')
-jest.mock('../utils/userProfileGroups', () => {
-  return {
-    getProfileAcceptedTypes: jest.fn().mockReturnValue('1,4,5,6'),
-  }
-})
+jest.mock('../utils/userProfileGroups')
 
 describe('generateReportController', () => {
+  let mockGetProfileAcceptedTypes: jest.Mock
+  let mockIsReportingAllowed: jest.Mock
   let mockGenerateReportService: jest.Mocked<GenerateReportService>
   let request: DeepMocked<Request>
   let response: DeepMocked<Response>
@@ -20,116 +19,142 @@ describe('generateReportController', () => {
   beforeEach(() => {
     request = createMock<Request>({})
     response = createMock<Response>({})
+    mockGetProfileAcceptedTypes = getProfileAcceptedTypes as jest.Mock
+    mockIsReportingAllowed = isReportingAllowed as jest.Mock
     mockGenerateReportService = new GenerateReportService(null) as jest.Mocked<GenerateReportService>
+    mockGetProfileAcceptedTypes.mockReturnValue('1,4,5,6')
+    mockIsReportingAllowed.mockReturnValue(true)
   })
 
-  it('should render generate report page', async () => {
-    const generateReportController = new GenerateReportController(mockGenerateReportService)
-    const requestHandler = generateReportController.show()
+  describe('show()', () => {
+    it('should render generate report page', async () => {
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.show()
 
-    await requestHandler(request, response, next)
+      await requestHandler(request, response, next)
 
-    expect(response.render).toHaveBeenCalledWith('pages/generateReport', { backUrl: '/' })
-  })
+      expect(response.render).toHaveBeenCalledWith('pages/generateReport', { backUrl: '/' })
+    })
 
-  it('should download the requested CRM report', async () => {
-    const crmReportResponse = getCrmReportResponse()
+    it('should throw error if reporting is not allowed', async () => {
+      mockIsReportingAllowed.mockReturnValue(false) // reporting not allowed
 
-    mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.show()
 
-    const generateReportController = new GenerateReportController(mockGenerateReportService)
-    const requestHandler = generateReportController.submit()
-    request.body = {
-      crmType: 'crm4',
-      startDate: '2023-03-01',
-      endDate: '2023-03-30',
-    }
-
-    await requestHandler(request, response, next)
-
-    expect(response.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename=crm4Report.csv')
-    expect(response.send).toHaveBeenCalledWith(crmReportResponse.text)
-
-    expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
-  })
-
-  it('should render generate report page with field errors', async () => {
-    const generateReportController = new GenerateReportController(mockGenerateReportService)
-    const requestHandler = generateReportController.submit()
-    request.body = {
-      crmType: '',
-      startDate: '2023-03-01',
-      endDate: '2023-03-30',
-    }
-
-    await requestHandler(request, response, next)
-
-    expect(response.render).toHaveBeenCalledWith('pages/generateReport', {
-      results: [],
-      errors: {
-        list: [
-          {
-            href: '#crmType',
-            text: 'CRM type must be selected',
-          },
-        ],
-        messages: {
-          crmType: {
-            text: 'CRM type must be selected',
-          },
-        },
-      },
-      backUrl: '/',
-      formValues: {
-        crmType: '',
-        startDate: '2023-03-01',
-        endDate: '2023-03-30',
-      },
+      await expect(requestHandler(request, response, next)).rejects.toThrow(new Error('Forbidden'))
     })
   })
 
-  it.each([
-    ['Not authorised to generate report', 401],
-    ['Not authorised to generate report', 403],
-    ['No report data found', 404],
-    ['Something went wrong with generate report', 500],
-  ])('should render generate page with "%s" error for status %s', async (errorMessage, errorStatus) => {
-    const crmReportResponse: CrmReportResponse = {
-      text: null,
-      error: {
-        status: errorStatus,
-        message: 'error',
-      },
-    }
+  describe('submit()', () => {
+    it('should download the requested CRM report', async () => {
+      const crmReportResponse = getCrmReportResponse()
 
-    mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
+      mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
 
-    const generateReportController = new GenerateReportController(mockGenerateReportService)
-    const requestHandler = generateReportController.submit()
-    request.body = {
-      crmType: 'crm4',
-      startDate: '2023-03-01',
-      endDate: '2023-03-30',
-    }
-
-    await requestHandler(request, response, next)
-
-    expect(response.render).toHaveBeenCalledWith('pages/generateReport', {
-      results: [],
-      errors: {
-        list: [
-          {
-            href: '#',
-            text: errorMessage,
-          },
-        ],
-      },
-      backUrl: '/',
-      formValues: {
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.submit()
+      request.body = {
         crmType: 'crm4',
         startDate: '2023-03-01',
         endDate: '2023-03-30',
-      },
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename=crm4Report.csv')
+      expect(response.send).toHaveBeenCalledWith(crmReportResponse.text)
+
+      expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
+    })
+
+    it('should throw error if reporting is not allowed', async () => {
+      mockIsReportingAllowed.mockReturnValue(false) // reporting not allowed
+
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.submit()
+
+      await expect(requestHandler(request, response, next)).rejects.toThrow(new Error('Forbidden'))
+    })
+
+    it('should render generate report page with field errors', async () => {
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.submit()
+      request.body = {
+        crmType: '',
+        startDate: '2023-03-01',
+        endDate: '2023-03-30',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('pages/generateReport', {
+        results: [],
+        errors: {
+          list: [
+            {
+              href: '#crmType',
+              text: 'CRM type must be selected',
+            },
+          ],
+          messages: {
+            crmType: {
+              text: 'CRM type must be selected',
+            },
+          },
+        },
+        backUrl: '/',
+        formValues: {
+          crmType: '',
+          startDate: '2023-03-01',
+          endDate: '2023-03-30',
+        },
+      })
+    })
+
+    it.each([
+      ['Not authorised to generate report', 401],
+      ['Not authorised to generate report', 403],
+      ['No report data found', 404],
+      ['Something went wrong with generate report', 500],
+    ])('should render generate page with "%s" error for status %s', async (errorMessage, errorStatus) => {
+      const crmReportResponse: CrmReportResponse = {
+        text: null,
+        error: {
+          status: errorStatus,
+          message: 'error',
+        },
+      }
+
+      mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
+
+      const generateReportController = new GenerateReportController(mockGenerateReportService)
+      const requestHandler = generateReportController.submit()
+      request.body = {
+        crmType: 'crm4',
+        startDate: '2023-03-01',
+        endDate: '2023-03-30',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('pages/generateReport', {
+        results: [],
+        errors: {
+          list: [
+            {
+              href: '#',
+              text: errorMessage,
+            },
+          ],
+        },
+        backUrl: '/',
+        formValues: {
+          crmType: 'crm4',
+          startDate: '2023-03-01',
+          endDate: '2023-03-30',
+        },
+      })
     })
   })
 })

--- a/server/controllers/generateReportController.test.ts
+++ b/server/controllers/generateReportController.test.ts
@@ -127,23 +127,6 @@ describe('GenerateReportController', () => {
       expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
     })
 
-    it('should handle errors during /generate-report/download route', async () => {
-      const error = new Error('Error generating report')
-      mockGenerateReportService.getCrmReport.mockRejectedValue(error)
-
-      const generateReportController = new GenerateReportController(mockGenerateReportService)
-      const requestHandler = generateReportController.download()
-
-      request.query = {
-        startDate: '2023-03-01',
-        endDate: '2023-03-30',
-      }
-
-      await expect(requestHandler(request, response, next)).rejects.toThrow('Error generating report')
-
-      expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
-    })
-
     it.each([
       ['Not authorised to generate report', 401],
       ['Not authorised to generate report', 403],

--- a/server/controllers/generateReportController.ts
+++ b/server/controllers/generateReportController.ts
@@ -4,8 +4,6 @@ import GenerateReportService from '../services/generateReportService'
 import validateReportParams from '../utils/generateReportValidation'
 import manageBackLink from '../utils/crmBackLink'
 import { buildErrors } from '../utils/errorDisplayHelper'
-import logger from '../../logger'
-import { SanitisedError } from '../sanitisedError'
 
 const CURRENT_URL = '/generate-report'
 const VIEW_PATH = 'pages/generateReport'

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -375,6 +375,49 @@ describe('routes', () => {
           expect(res.text).toContain('Generate reports')
         })
     })
+
+    it('should render error page with forbidden error', () => {
+      mockIsReportingAllowed.mockReturnValue(false)
+
+      return request(app)
+        .get('/generate-report')
+        .expect(403)
+        .expect(res => {
+          expect(res.text).toContain('Error: Forbidden')
+        })
+    })
+  })
+
+  describe('POST /generate-report', () => {
+    it('should post generate report form and redirect to download', () => {
+      return request(app)
+        .post('/generate-report')
+        .send({
+          crmType: 'crm4',
+          startDate: '2023-03-01',
+          endDate: '2023-03-30',
+        })
+        .expect(res => {
+          expect(res.status).toEqual(302)
+          expect(res.headers.location).toEqual('/generate-report')
+        })
+    })
+
+    it('should render error page with forbidden error', () => {
+      mockIsReportingAllowed.mockReturnValue(false)
+
+      return request(app)
+        .post('/generate-report')
+        .send({
+          crmType: 'crm4',
+          startDate: '2022-11-01',
+          endDate: '2023-11-02',
+        })
+        .expect(403)
+        .expect(res => {
+          expect(res.text).toContain('Error: Forbidden')
+        })
+    })
   })
 
   describe('GET /generate-report/download', () => {
@@ -393,6 +436,17 @@ describe('routes', () => {
         .expect(res => {
           expect(res.text).toBe(reportData)
           expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
+        })
+    })
+
+    it('should render error page with forbidden error', () => {
+      mockIsReportingAllowed.mockReturnValue(false)
+
+      return request(app)
+        .get('/generate-report/download?startDate=2023-03-01&endDate=2023-03-30')
+        .expect(403)
+        .expect(res => {
+          expect(res.text).toContain('Error: Forbidden')
         })
     })
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,6 +3,9 @@ import { type NextFunction, type Request, type RequestHandler, type Response, Ro
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import { Controllers } from '../controllers'
 import config from '../config'
+import { isReportingAllowed } from '../utils/userProfileGroups'
+import logger from '../../logger'
+import { SanitisedError } from '../sanitisedError'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes({
@@ -35,8 +38,30 @@ export default function routes({
     return next()
   })
 
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (routePath: string, handler: RequestHandler) => router.post(routePath, asyncMiddleware(handler))
+  const get = (path: string | string[], handler: RequestHandler, requestChecker?: RequestHandler) => {
+    if (requestChecker) {
+      return router.get(path, asyncMiddleware(requestChecker), asyncMiddleware(handler))
+    }
+    return router.get(path, asyncMiddleware(handler))
+  }
+
+  const post = (path: string | string[], handler: RequestHandler, requestChecker?: RequestHandler) => {
+    if (requestChecker) {
+      return router.post(path, asyncMiddleware(requestChecker), asyncMiddleware(handler))
+    }
+    return router.post(path, asyncMiddleware(handler))
+  }
+
+  const checkReportingAllowed = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    if (!isReportingAllowed(res)) {
+      // throw forbidden error
+      logger.error('Not authorised to generate report')
+      const error = new Error('Forbidden') as SanitisedError
+      error.status = 403
+      throw error
+    }
+    return next()
+  }
 
   get('/', homeController.show())
 
@@ -52,11 +77,11 @@ export default function routes({
 
   get('/crm14/:usn/:sectionId?', crm14Controller.show())
 
-  get('/generate-report', generateReportController.show())
+  get('/generate-report', generateReportController.show(), checkReportingAllowed)
 
-  post('/generate-report', generateReportController.submit())
+  post('/generate-report', generateReportController.submit(), checkReportingAllowed)
 
-  get('/generate-report/download', generateReportController.download())
+  get('/generate-report/download', generateReportController.download(), checkReportingAllowed)
 
   get('/download-evidence', downloadEvidenceController.download())
 


### PR DESCRIPTION
**Changes made:**

- Added isReportingAllowed check to generate-reports routes and throw 403 error when required
- Removed API call from generateReportController.submit()
- Moved API error handling to generateReportService.download()
- Added/Updated unit tests
