### PR TITLE
EMP-446   FE: Fix Generate Report Controller to call API only once

### DIFF
--- a/assets/js/triggerDownload.js
+++ b/assets/js/triggerDownload.js
@@ -1,6 +1,13 @@
 document.addEventListener('DOMContentLoaded', function () {
-  const downloadUrl = document.getElementById('download-url')
-  if (downloadUrl) {
-    window.location.href = downloadUrl.value
+  const csvContent = document.getElementById('csv-content')?.value
+  if (csvContent) {
+    const blob = new Blob([csvContent], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'crmReport.csv'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
   }
 })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -20,7 +20,7 @@ declare module 'express-session' {
     errors?: Record<string, { text: string }>
     errorSummary?: Array<{ href: string; text: string }>
     successMessage?: string
-    downloadUrl?: string
+    csvContent?: string
     pkceCodes: PkceCodes
     authCodeUrlRequest: AuthorizationUrlRequest
     authCodeRequest: AuthorizationCodeRequest

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -389,7 +389,7 @@ describe('routes', () => {
   })
 
   describe('POST /generate-report', () => {
-    it('should post generate report form and redirect to download', () => {
+    it('should post generate report form and redirect to the same page with success message', () => {
       mockGenerateReportService.getCrmReport.mockResolvedValue({
         text:
           'Client UFN,Usn,Provider Account,Firm Name,Client Name,Rep Order Number,Maat ID,Prison Law,Date Received,' +
@@ -409,6 +409,7 @@ describe('routes', () => {
         .expect(res => {
           expect(res.status).toEqual(302)
           expect(res.headers.location).toEqual('/generate-report')
+          // You may want to add assertions to check that the session has the expected success message and CSV content
         })
     })
 
@@ -425,48 +426,6 @@ describe('routes', () => {
         .expect(403)
         .expect(res => {
           expect(res.text).toContain('Error: Forbidden')
-        })
-    })
-  })
-
-  describe('GET /generate-report/download', () => {
-    it('should download the generated report', async () => {
-      const reportData = 'sample,csv,data\n1,2,3'
-
-      mockGenerateReportService.getCrmReport.mockResolvedValue({
-        text: reportData,
-      })
-
-      return request(app)
-        .get('/generate-report/download?startDate=2023-03-01&endDate=2023-03-30')
-        .expect('Content-Type', /text\/csv/)
-        .expect('Content-Disposition', 'attachment; filename=crmReport.csv')
-        .expect(200)
-        .expect(res => {
-          expect(res.text).toBe(reportData)
-          expect(mockGenerateReportService.getCrmReport).toHaveBeenCalledWith('2023-03-01', '2023-03-30', '1,4,5,6')
-        })
-    })
-
-    it('should render error page with forbidden error', () => {
-      mockIsReportingAllowed.mockReturnValue(false)
-
-      return request(app)
-        .get('/generate-report/download?startDate=2023-03-01&endDate=2023-03-30')
-        .expect(403)
-        .expect(res => {
-          expect(res.text).toContain('Error: Forbidden')
-        })
-    })
-
-    it('should handle errors during report generation', async () => {
-      mockGenerateReportService.getCrmReport.mockRejectedValue(new Error('Error generating report'))
-
-      return request(app)
-        .get('/generate-report/download?startDate=2023-03-01&endDate=2023-03-30')
-        .expect(500)
-        .expect(res => {
-          expect(res.text).toContain('Error generating report')
         })
     })
   })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -81,8 +81,6 @@ export default function routes({
 
   post('/generate-report', generateReportController.submit(), checkReportingAllowed)
 
-  get('/generate-report/download', generateReportController.download(), checkReportingAllowed)
-
   get('/download-evidence', downloadEvidenceController.download())
 
   return router

--- a/server/views/pages/generateReport.njk
+++ b/server/views/pages/generateReport.njk
@@ -14,8 +14,8 @@
         {{ backLink(backUrl) }}
         <main class="govuk-main-wrapper">
 
-            {% if downloadUrl %}
-                <input type="hidden" id="download-url" value="{{ downloadUrl }}">
+            {% if csvContent %}
+                <input type="hidden" id="csv-content" value="{{ csvContent }}">
             {% endif %}
 
             <!-- Display success message -->


### PR DESCRIPTION
Changes - 

- amended generateReport.njk
- removed download request handler from generateReportController.ts 
- amended generateReportController.test.ts
- amended types/express/index.d.ts
- removed download from routes/index.ts
- removed download test from index.test.ts
- amended triggerDownload.js to include download logic