### PR TITLE
EMP-457 - Defect Fix - Fixing clientNfa missing field in crm5 response

### DIFF
--- a/server/services/config/crm5DisplayConfig.json
+++ b/server/services/config/crm5DisplayConfig.json
@@ -140,11 +140,11 @@
               "apiField": "ClientDetails.maritalStatus"
             },
             {
-              "label": "Client has no fixed abode",
-              "apiField": "ClientDetails.clientNfa"
+              "subHeading": "Address"
             },
             {
-              "subHeading": "Address"
+              "label": "Client has no fixed abode",
+              "apiField": "ClientDetails.clientNfa"
             },
             {
               "label": "Client has no fixed abode",


### PR DESCRIPTION
# Defect Fix
Minor Fix to move the `clientNfa` label below `Address` label