### PR TITLE
EMP-556: Standard properties section time format

### DIFF
--- a/server/services/config/crm4DisplayConfig.json
+++ b/server/services/config/crm4DisplayConfig.json
@@ -239,7 +239,7 @@
             {
               "label": "Preparation Hours",
               "apiField": "ExpenditureDetails.Preparation.hours",
-              "type": "time"
+              "type": "hours"
             },
             {
               "label": "Hourly Rate",
@@ -361,7 +361,7 @@
             {
               "label": "No. of Hours",
               "apiField": "ExpenditureDetails.Travel.hours",
-              "type": "time"
+              "type": "hours"
             },
             {
               "label": "Hourly Rate",

--- a/server/utils/crmDisplayConfigValidation.ts
+++ b/server/utils/crmDisplayConfigValidation.ts
@@ -27,7 +27,7 @@ const schema = Joi.object({
               label: Joi.string().optional().allow(''),
               apiField: Joi.string().required(),
               type: Joi.string()
-                .valid('currency', 'date', 'multiline', 'percent', 'time', 'timeAndCost', 'totalAndCost')
+                .valid('currency', 'date', 'hours', 'multiline', 'percent', 'time', 'timeAndCost', 'totalAndCost')
                 .optional(),
               transform: Joi.string()
                 .valid(

--- a/server/utils/crmFieldFormatter.test.ts
+++ b/server/utils/crmFieldFormatter.test.ts
@@ -94,11 +94,6 @@ describe('CRM Field Formatter', () => {
     })
 
     it('should format time into hours and minutes (am)', () => {
-      const result = formatTime('09:06:34')
-      expect(result).toEqual('9:06am')
-    })
-
-    it('should format time into hours and minutes (am)', () => {
       const result = formatTime('00:06:34')
       expect(result).toEqual('12:06am')
     })

--- a/server/utils/crmFieldFormatter.test.ts
+++ b/server/utils/crmFieldFormatter.test.ts
@@ -76,6 +76,11 @@ describe('CRM Field Formatter', () => {
       expect(result).toEqual('36 hrs 32 mins')
     })
 
+    it('should format time with short format', () => {
+      const result = formatHours('36:32:00', true)
+      expect(result).toEqual('36:32')
+    })
+
     it('should not format time if not a valid time', () => {
       const result = formatHours('blah')
       expect(result).toEqual('blah')
@@ -96,11 +101,6 @@ describe('CRM Field Formatter', () => {
     it('should format time into hours and minutes (am)', () => {
       const result = formatTime('00:06:34')
       expect(result).toEqual('12:06am')
-    })
-
-    it('should format time with custom format', () => {
-      const result = formatTime('15:32:11', 'HH:mm')
-      expect(result).toEqual('15:32')
     })
 
     it('should not format time if not a valid time', () => {

--- a/server/utils/crmFieldFormatter.test.ts
+++ b/server/utils/crmFieldFormatter.test.ts
@@ -1,5 +1,12 @@
 import { runtime } from 'nunjucks'
-import { formatBooleanToYesNo, formatCurrency, formatDate, formatMultiline, formatTime } from './crmFieldFormatter'
+import {
+  formatBooleanToYesNo,
+  formatCurrency,
+  formatDate,
+  formatHours,
+  formatMultiline,
+  formatTime,
+} from './crmFieldFormatter'
 import SafeString = runtime.SafeString
 
 describe('CRM Field Formatter', () => {
@@ -63,15 +70,32 @@ describe('CRM Field Formatter', () => {
     })
   })
 
-  describe('formatTime', () => {
+  describe('formatHours', () => {
     it('should format time into hours and minutes', () => {
-      const result = formatTime('15:32:11')
-      expect(result).toEqual('15 hrs 32 mins')
+      const result = formatHours('36:32:11')
+      expect(result).toEqual('36 hrs 32 mins')
     })
 
-    it('should format time with single-digit hours and minutes', () => {
-      const result = formatTime('5:07:00')
-      expect(result).toEqual('05 hrs 07 mins')
+    it('should not format time if not a valid time', () => {
+      const result = formatHours('blah')
+      expect(result).toEqual('blah')
+    })
+  })
+
+  describe('formatTime', () => {
+    it('should format time into hours and minutes (pm)', () => {
+      const result = formatTime('15:32:11')
+      expect(result).toEqual('3:32pm')
+    })
+
+    it('should format time into hours and minutes (am)', () => {
+      const result = formatTime('09:06:34')
+      expect(result).toEqual('9:06am')
+    })
+
+    it('should format time into hours and minutes (am)', () => {
+      const result = formatTime('00:06:34')
+      expect(result).toEqual('12:06am')
     })
 
     it('should format time with custom format', () => {

--- a/server/utils/crmFieldFormatter.ts
+++ b/server/utils/crmFieldFormatter.ts
@@ -55,7 +55,7 @@ export const formatTime = (value: string): string => {
     return value
   }
 
-  return format(timeAsDate, 'h:mmaaa').replace(/\s/g, '')
+  return format(timeAsDate, 'h:mmaaa')
 }
 
 export const formatPercentage = (value: string): string => {

--- a/server/utils/crmFieldFormatter.ts
+++ b/server/utils/crmFieldFormatter.ts
@@ -39,24 +39,20 @@ export const formatMultiline = (value: string | object) => {
   return value
 }
 
-export const formatHours = (value: string = ''): string => {
+export const formatHours = (value: string = '', shortFormat: boolean = false): string => {
   const parts = value.split(':')
   if (parts.length > 1) {
     const [hours, minutes] = parts
-    return `${hours} hrs ${minutes} mins`
+    return shortFormat ? `${hours}:${minutes}` : `${hours} hrs ${minutes} mins`
   }
 
   return value
 }
 
-export const formatTime = (value: string, dateFormat?: string): string => {
+export const formatTime = (value: string): string => {
   const timeAsDate = Date.parse(`${new Date().toDateString()} ${value}`)
   if (Number.isNaN(timeAsDate)) {
     return value
-  }
-
-  if (dateFormat) {
-    return format(timeAsDate, dateFormat)
   }
 
   return format(timeAsDate, 'h:mmaaa').replace(/\s/g, '')

--- a/server/utils/crmFieldFormatter.ts
+++ b/server/utils/crmFieldFormatter.ts
@@ -39,6 +39,16 @@ export const formatMultiline = (value: string | object) => {
   return value
 }
 
+export const formatHours = (value: string = ''): string => {
+  const parts = value.split(':')
+  if (parts.length > 1) {
+    const [hours, minutes] = parts
+    return `${hours} hrs ${minutes} mins`
+  }
+
+  return value
+}
+
 export const formatTime = (value: string, dateFormat?: string): string => {
   const timeAsDate = Date.parse(`${new Date().toDateString()} ${value}`)
   if (Number.isNaN(timeAsDate)) {
@@ -49,9 +59,7 @@ export const formatTime = (value: string, dateFormat?: string): string => {
     return format(timeAsDate, dateFormat)
   }
 
-  const formattedTime = format(timeAsDate, 'HH:mm')
-  const [hours, minutes] = formattedTime.split(':')
-  return `${hours} hrs ${minutes} mins`
+  return format(timeAsDate, 'h:mmaaa').replace(/\s/g, '')
 }
 
 export const formatPercentage = (value: string): string => {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,6 +9,7 @@ import {
   formatBooleanToYesNo,
   formatCurrency,
   formatDate,
+  formatHours,
   formatMultiline,
   formatPercentage,
   formatTime,
@@ -53,6 +54,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
 
   njkEnv.addFilter('formatCurrency', formatCurrency)
   njkEnv.addFilter('formatDate', formatDate)
+  njkEnv.addFilter('formatHours', formatHours)
   njkEnv.addFilter('formatMultiline', formatMultiline)
   njkEnv.addFilter('formatPercentage', formatPercentage)
   njkEnv.addFilter('formatTime', formatTime)

--- a/server/views/components/customDisplay/crm4/crm4AlternativeQuotes.njk
+++ b/server/views/components/customDisplay/crm4/crm4AlternativeQuotes.njk
@@ -17,11 +17,11 @@
             { label: "Name Of Expert", value: quote.expertName },
             { label: "Contact Phone", value: quote.contactPhone },
             { label: "Cost Basis", value: quote.costBasis },
-            { label: "Preparation Hours", value: quote.preparationHours, type: "time" },
+            { label: "Preparation Hours", value: quote.preparationHours, type: "hours" },
             { label: "Preparation Hourly Rate", value: quote.hourlyRate, type: "currency" },
             { label: "Additional Items Description", value: quote.additionalItemDesc },
             { label: "Additional Items Amount", value: quote.additionalItemAmount,  type: "currency" },
-            { label: "Travel Hours", value: quote.travelHours, type: "time" },
+            { label: "Travel Hours", value: quote.travelHours, type: "hours" },
             { label: "Travel Hourly Rate", value: quote.travelHourlyRate, type: "currency"  },
             { label: "Total", value: quote.quoteTotal, type: "currency" }
         ] %}

--- a/server/views/components/timeAndCost.njk
+++ b/server/views/components/timeAndCost.njk
@@ -23,7 +23,7 @@
                 <div class="govuk-grid-column-one-half">
                     <div class="govuk-body govuk-min-height  govuk-!-margin-bottom-0">
                         {% if not isTotalRow %}
-                            {{ timeAndCost.time | formatTime }}
+                            {{ timeAndCost.time | formatHours }}
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
**Changes made:**

- Updated 'Preparation Hours', 'No. of Hours' to use 'hours' type in crm4DisplayConfig
- Updated 'Preparation Hours', 'No. of Hours' to use 'hours' type in crm4AlternativeQuotes
- Added formatHours as a nunjucks filter
- Added hours to type validation in crmDisplayConfig validation
- Added formatHours and updated formatTime in crmFieldFormatter
- Modified timeAndCost component to use formatHours
- Updated unit tests
