### PR TITLE
EMP-618: Evidence attachment not downloading with correct extension

### DIFF
--- a/server/controllers/downloadEvidenceController.ts
+++ b/server/controllers/downloadEvidenceController.ts
@@ -17,7 +17,7 @@ export default class DownloadEvidenceController {
       const fileResponse = await superagent.get(fileUrl).set('Content-Type', 'application/octet-stream')
 
       // return evidence with required file name
-      res.setHeader('Content-Disposition', `attachment; filename=${fileName}`)
+      res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
       res.send(fileResponse.body)
     }
   }


### PR DESCRIPTION
**Changes made:**
- Escape filename in downloadEvidenceController.ts
- Updated unit tests