### PR TITLE
EMP-398 Modify formatMultiline to use \r

### DIFF
--- a/server/utils/crmFieldFormatter.test.ts
+++ b/server/utils/crmFieldFormatter.test.ts
@@ -60,11 +60,8 @@ describe('CRM Field Formatter', () => {
 
   describe('formatMultiline', () => {
     it.each([
-      [
-        'This is line1.\nThis is line2.#13;\nThis is line3.#13;',
-        'This is line1.<br>This is line2.<br>This is line3.<br>',
-      ],
-      [new SafeString('UBER EATS#13;\nUber driver'), 'UBER EATS<br>Uber driver'], // nunjucks safe string
+      ['This is line1.\nThis is line2.\r\nThis is line3.\r', 'This is line1.<br>This is line2.<br>This is line3.<br>'],
+      [new SafeString('UBER EATS\r\nUber driver'), 'UBER EATS<br>Uber driver'], // nunjucks safe string
     ])('given %s returns "%s"', (input: string | object, expected: string) => {
       expect(formatMultiline(input)).toEqual(expected)
     })

--- a/server/utils/crmFieldFormatter.ts
+++ b/server/utils/crmFieldFormatter.ts
@@ -34,7 +34,7 @@ export const formatDate = (value: string, dateFormat?: string): string => {
 export const formatMultiline = (value: string | object) => {
   if (typeof value === 'string' || value instanceof SafeString) {
     const valueAsString = value as string
-    return valueAsString.replace(/(\n|#13;\n|#13;)/g, '<br>')
+    return valueAsString.replace(/(\n|\r\n|\r)/g, '<br>')
   }
   return value
 }


### PR DESCRIPTION
**Changes made:**

- Modify formatMultiline to use \r in crmFieldFormatter.test.ts
- Updated tests