### PR TITLE
EMP-663-accessibility-e-form-details-page-5-evidence-section-download-links-add-hidden-text-after-the-link-or-an-aria-label-to-distinguish-what-the-user-is-downloading

### DIFF
--- a/server/utils/crmFieldFormatter.ts
+++ b/server/utils/crmFieldFormatter.ts
@@ -67,3 +67,10 @@ export const formatPercentage = (value: string): string => {
 export const splitCamelCase = (value: string): string => {
   return value.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase()
 }
+
+export const removeUnderscore = (value: string): string => {
+  return value
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, char => char.toUpperCase())
+}

--- a/server/utils/crmFieldFormatter.ts
+++ b/server/utils/crmFieldFormatter.ts
@@ -63,14 +63,3 @@ export const formatPercentage = (value: string): string => {
   if (Number.isNaN(number)) return value
   return `${number}%`
 }
-
-export const splitCamelCase = (value: string): string => {
-  return value.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase()
-}
-
-export const removeUnderscore = (value: string): string => {
-  return value
-    .replace(/_/g, ' ')
-    .toLowerCase()
-    .replace(/\b\w/g, char => char.toUpperCase())
-}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -14,6 +14,7 @@ import {
   formatPercentage,
   formatTime,
   splitCamelCase,
+  removeUnderscore,
 } from './crmFieldFormatter'
 
 import transformValue from './crmFieldTransformer'
@@ -63,4 +64,5 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('isNotEmpty', isNotEmpty)
   njkEnv.addFilter('splitCamelCase', splitCamelCase)
   njkEnv.addFilter('transformValue', transformValue)
+  njkEnv.addFilter('removeUnderscore', removeUnderscore)
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,7 +2,7 @@
 import path from 'path'
 import nunjucks from 'nunjucks'
 import express from 'express'
-import { initialiseName, isNotEmpty } from './utils'
+import { initialiseName, isNotEmpty, splitCamelCase, removeUnderscore } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import {
@@ -13,8 +13,6 @@ import {
   formatMultiline,
   formatPercentage,
   formatTime,
-  splitCamelCase,
-  removeUnderscore,
 } from './crmFieldFormatter'
 
 import transformValue from './crmFieldTransformer'

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,11 @@
-import { buildQueryString, convertToTitleCase, initialiseName, isNotEmpty } from './utils'
+import {
+  buildQueryString,
+  convertToTitleCase,
+  initialiseName,
+  isNotEmpty,
+  splitCamelCase,
+  removeUnderscore,
+} from './utils'
 
 describe('buildQueryString', () => {
   it.each([
@@ -53,5 +60,32 @@ describe('isNotEmpty', () => {
     ['', false],
   ])('given "%s" returns %s', (input: string, expected: boolean) => {
     expect(isNotEmpty(input)).toEqual(expected)
+  })
+})
+
+describe('splitCamelCase', () => {
+  it.each([
+    ['camelCase', 'camel case'],
+    ['CamelCaseTest', 'camel case test'],
+    ['already separated', 'already separated'],
+    ['lowerCase', 'lower case'],
+    ['SingleWord', 'single word'],
+    ['', ''],
+  ])('given "%s" returns "%s"', (input: string, expected: string) => {
+    expect(splitCamelCase(input)).toEqual(expected)
+  })
+})
+
+describe('removeUnderscore', () => {
+  it.each([
+    ['WAGE_SLIPS', 'Wage Slips'],
+    ['INCOME_SUPPORT', 'Income Support'],
+    ['rent_mortgage', 'Rent Mortgage'],
+    ['alreadyWithoutUnderscore', 'Alreadywithoutunderscore'],
+    ['', ''],
+    ['single_word', 'Single Word'],
+    ['multiple__underscores', 'Multiple  Underscores'],
+  ])('given "%s" returns "%s"', (input: string, expected: string) => {
+    expect(removeUnderscore(input)).toEqual(expected)
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -42,3 +42,14 @@ export const currentIsoDate = (): string => {
 export const isNotEmpty = (value: string): boolean => {
   return value !== undefined && value !== null && value !== ''
 }
+
+export const splitCamelCase = (value: string): string => {
+  return value.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase()
+}
+
+export const removeUnderscore = (value: string): string => {
+  return value
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, char => char.toUpperCase())
+}

--- a/server/views/components/customDisplay/crmEvidence.njk
+++ b/server/views/components/customDisplay/crmEvidence.njk
@@ -28,11 +28,16 @@
             {% set fileKey = "CRM14/" + item.key if crmType === "CRM 14" and (item.key | truncate(4, true, '')) === "att_" else item.key %}
             {% set fileName = item.name | replace("'", "") | urlencode %}
             {% set linkUrl = "/download-evidence?fileKey=" + (fileKey | urlencode) + "&fileName=" + fileName %}
+
+            {# Add aria-label to describe the type of file being downloaded #}
+            {% set ariaLabel = "Download " + (item.type | removeUnderscore ) + " evidence file" %}
+
             {% set tableRow = [
                 { text: "Attachment " ~ loop.index, isHeader: true },
                 { text: item.name },
-                { text: "<a href='" + linkUrl + "' class='govuk-link govuk-link--no-visited-state'>" + "Download" + "</a>", html: true }
+                { text: "<a href='" + linkUrl + "' class='govuk-link govuk-link--no-visited-state' aria-label='" + ariaLabel + "'>" + "Download" + "</a>", html: true }
             ] %}
+
             {% set _ = tableEvidence.rows.push(tableRow) %}
         {% endfor %}
 


### PR DESCRIPTION
Changes - 

- amended crmEvidence.njk
- added filter to crmFieldFormatter.ts
- amended nunjucksSetup.ts