### PR TITLE
EMP-732: Refactor handling of API error responses

### DIFF
--- a/server/@types/crmReport/index.d.ts
+++ b/server/@types/crmReport/index.d.ts
@@ -18,7 +18,7 @@ type CrmReportRequest = {
 
 type CrmReportResponse = {
   text: string
-  error?: CrmReportError
+  errorMessage?: string
 }
 
 export { CrmReportRequest, CrmReportResponse, CrmReportError }

--- a/server/@types/crmReport/index.d.ts
+++ b/server/@types/crmReport/index.d.ts
@@ -1,8 +1,3 @@
-type CrmReportError = {
-  status: number
-  message: string
-}
-
 type CrmReportRequest = {
   crmType: CrmType
   decisionFromDate?: string
@@ -21,4 +16,4 @@ type CrmReportResponse = {
   errorMessage?: string
 }
 
-export { CrmReportRequest, CrmReportResponse, CrmReportError }
+export { CrmReportRequest, CrmReportResponse }

--- a/server/@types/searchEform/index.d.ts
+++ b/server/@types/searchEform/index.d.ts
@@ -43,7 +43,7 @@ type SearchPaging = {
 type SearchResponse = {
   results: Array<SearchResult>
   paging?: SearchPaging
-  error?: SearchError
+  errorMessage?: string
 }
 
 export type { SearchRequest, SearchResponse, SearchError, SearchResult }

--- a/server/@types/searchEform/index.d.ts
+++ b/server/@types/searchEform/index.d.ts
@@ -11,11 +11,6 @@ type SearchResult = {
   crmLink?: string
 }
 
-type SearchError = {
-  status: number
-  message: string
-}
-
 type SearchRequest = {
   usn?: string
   type?: number
@@ -46,4 +41,4 @@ type SearchResponse = {
   errorMessage?: string
 }
 
-export type { SearchRequest, SearchResponse, SearchError, SearchResult }
+export type { SearchRequest, SearchResponse, SearchResult }

--- a/server/controllers/generateReportController.test.ts
+++ b/server/controllers/generateReportController.test.ts
@@ -113,18 +113,10 @@ describe('GenerateReportController', () => {
       expect(mockGenerateReportService.getCrmReport).not.toHaveBeenCalled()
     })
 
-    it.each([
-      ['Not authorised to generate report', 401],
-      ['Not authorised to generate report', 403],
-      ['No report data found', 404],
-      ['Something went wrong with generate report', 500],
-    ])('should render generate page with "%s" error for status %s', async (errorMessage, errorStatus) => {
+    it('should render generate page with error', async () => {
       const crmReportResponse: CrmReportResponse = {
         text: null,
-        error: {
-          status: errorStatus,
-          message: 'error',
-        },
+        errorMessage: 'Some error',
       }
 
       mockGenerateReportService.getCrmReport.mockResolvedValue(crmReportResponse)
@@ -145,7 +137,7 @@ describe('GenerateReportController', () => {
           list: [
             {
               href: '#',
-              text: errorMessage,
+              text: 'Some error',
             },
           ],
         },

--- a/server/controllers/generateReportController.ts
+++ b/server/controllers/generateReportController.ts
@@ -50,9 +50,9 @@ export default class GenerateReportController {
         const crmReportResponse = await this.generateReportService.getCrmReport(crmReportRequest)
 
         // check for any errors in the report response
-        if (crmReportResponse.error) {
+        if (crmReportResponse.errorMessage) {
           // render with errors for report API error
-          const errors = buildErrors(crmReportResponse.error, this.getErrorMessage)
+          const errors = buildErrors(crmReportResponse.errorMessage)
           res.render(VIEW_PATH, {
             results: [],
             errors,
@@ -65,18 +65,6 @@ export default class GenerateReportController {
           res.send(crmReportResponse.text)
         }
       }
-    }
-  }
-
-  private getErrorMessage(errorStatus: number): string {
-    switch (errorStatus) {
-      case 401:
-      case 403:
-        return 'Not authorised to generate report'
-      case 404:
-        return 'No report data found'
-      default:
-        return 'Something went wrong with generate report'
     }
   }
 

--- a/server/controllers/searchEformController.test.ts
+++ b/server/controllers/searchEformController.test.ts
@@ -214,19 +214,12 @@ describe('Search Eform Controller', () => {
     expect(mockSearchEformService.search).not.toHaveBeenCalled()
   })
 
-  it.each([
-    ['Not authorised to search', 401],
-    ['Not authorised to search', 403],
-    ['No search result found', 404],
-    ['Something went wrong with the search', 500],
-  ])('should render search eform with "%s" error for status %s', async (errorMessage, errorStatus) => {
+  it('should render search eform with error', async () => {
     const searchResponse: SearchResponse = {
       results: [],
-      error: {
-        status: errorStatus,
-        message: 'error',
-      },
+      errorMessage: 'Some error',
     }
+
     mockSearchEformService.search.mockResolvedValue(searchResponse)
 
     const searchEformController = new SearchEformController(mockSearchEformService)
@@ -244,7 +237,7 @@ describe('Search Eform Controller', () => {
         list: [
           {
             href: '#',
-            text: errorMessage,
+            text: 'Some error',
           },
         ],
       },

--- a/server/controllers/searchEformController.ts
+++ b/server/controllers/searchEformController.ts
@@ -57,10 +57,10 @@ export default class SearchEformController {
           const searchRequest = this.buildSearchRequest(searchParams, getProfileAcceptedTypes(res))
           const searchResponse = await this.searchEformService.search(searchRequest)
 
-          if (searchResponse.error) {
+          if (searchResponse.errorMessage) {
             // render with errors for search API error
-            const searchErrors = buildErrors(searchResponse.error, this.getErrorMessage)
-            res.render(VIEW_PATH, { results: [], errors: searchErrors, formValues: searchParams, backUrl })
+            const errors = buildErrors(searchResponse.errorMessage)
+            res.render(VIEW_PATH, { results: [], errors, formValues: searchParams, backUrl })
           } else {
             // render with search results
             const { results, paging } = searchResponse
@@ -108,18 +108,6 @@ export default class SearchEformController {
 
       const queryString = buildQueryString(formValues)
       res.redirect(302, `/search-eform?page=1${queryString ? `&${queryString}` : ''}`)
-    }
-  }
-
-  private getErrorMessage(errorStatus: number): string {
-    switch (errorStatus) {
-      case 401:
-      case 403:
-        return 'Not authorised to search'
-      case 404:
-        return 'No search result found'
-      default:
-        return 'Something went wrong with the search'
     }
   }
 

--- a/server/services/generateReportService.test.ts
+++ b/server/services/generateReportService.test.ts
@@ -70,12 +70,17 @@ describe('Generate Report Service', () => {
     })
   })
 
-  it('should return error', async () => {
+  it.each([
+    ['Not authorised to generate report', 401],
+    ['Not authorised to generate report', 403],
+    ['No report data found', 404],
+    ['Something went wrong with generate report', 500],
+  ])('should return error "%s" error for status %s', async (errorMessage, errorStatus) => {
     const error: SanitisedError = {
       name: 'some error',
       message: 'some message',
       stack: 'some stack',
-      status: 404,
+      status: errorStatus,
       text: 'error',
     }
     mockCrmReportApiClient.getCrmReport.mockRejectedValue(error)
@@ -90,11 +95,8 @@ describe('Generate Report Service', () => {
     })
 
     expect(result).toEqual({
-      error: {
-        message: 'some message',
-        status: 404,
-      },
       text: null,
+      errorMessage,
     })
 
     expect(mockCrmReportApiClient.getCrmReport).toHaveBeenCalledWith({

--- a/server/services/generateReportService.ts
+++ b/server/services/generateReportService.ts
@@ -18,7 +18,7 @@ export default class GenerateReportService {
       return successResponse(response.text)
     } catch (error) {
       logger.error('Report API error', error)
-      return errorResponse(error.status, error.message)
+      return errorResponse(error.status)
     }
   }
 }
@@ -29,9 +29,21 @@ const successResponse = (data: string): CrmReportResponse => {
   }
 }
 
-const errorResponse = (status: number, message: string): CrmReportResponse => {
+const errorResponse = (errorStatus: number): CrmReportResponse => {
   return {
     text: null,
-    error: { status, message },
+    errorMessage: getErrorMessage(errorStatus),
+  }
+}
+
+const getErrorMessage = (errorStatus: number): string => {
+  switch (errorStatus) {
+    case 401:
+    case 403:
+      return 'Not authorised to generate report'
+    case 404:
+      return 'No report data found'
+    default:
+      return 'Something went wrong with generate report'
   }
 }

--- a/server/services/searchEformService.test.ts
+++ b/server/services/searchEformService.test.ts
@@ -83,12 +83,17 @@ describe('Search Eform Service', () => {
     })
   })
 
-  it('should search and return error', async () => {
+  it.each([
+    ['Not authorised to search', 401],
+    ['Not authorised to search', 403],
+    ['No search result found', 404],
+    ['Something went wrong with the search', 500],
+  ])('should render search eform with "%s" error for status %s', async (errorMessage, errorStatus) => {
     const error: SanitisedError = {
       name: 'some error',
       message: 'some message',
       stack: 'some stack',
-      status: 404,
+      status: errorStatus,
       text: 'error',
     }
 
@@ -104,10 +109,7 @@ describe('Search Eform Service', () => {
     })
 
     expect(result).toEqual({
-      error: {
-        message: 'some message',
-        status: 404,
-      },
+      errorMessage,
       results: [],
     })
     expect(mockSearchApiClient.search).toHaveBeenCalledWith({
@@ -142,10 +144,7 @@ describe('Search Eform Service', () => {
       profileAcceptedTypes: '1,4,5,6',
     })
     expect(result).toEqual({
-      error: {
-        message: 'No search results found',
-        status: 500,
-      },
+      errorMessage: 'No search result found',
       results: [],
     })
     expect(mockSearchApiClient.search).toHaveBeenCalledWith({

--- a/server/services/searchEformService.ts
+++ b/server/services/searchEformService.ts
@@ -10,20 +10,13 @@ export default class SearchEformService {
       const response = await this.searchApiClient.search(searchRequest)
       if (response.results.length === 0) {
         logger.error('No results returned by search API')
-        return errorResponse(500, 'No search results found')
+        return errorResponse(404)
       }
       return successResponse(response)
     } catch (error) {
       logger.error('Search API error', error)
-      return errorResponse(error.status, error.message)
+      return errorResponse(error.status)
     }
-  }
-}
-
-const errorResponse = (status: number, message: string): SearchResponse => {
-  return {
-    results: [],
-    error: { status, message },
   }
 }
 
@@ -35,6 +28,25 @@ const successResponse = (searchResponse: SearchResponse): SearchResponse => {
   return {
     ...searchResponse,
     results: resultsWithLinks,
+  }
+}
+
+const errorResponse = (errorStatus: number): SearchResponse => {
+  return {
+    results: [],
+    errorMessage: getErrorMessage(errorStatus),
+  }
+}
+
+const getErrorMessage = (errorStatus: number): string => {
+  switch (errorStatus) {
+    case 401:
+    case 403:
+      return 'Not authorised to search'
+    case 404:
+      return 'No search result found'
+    default:
+      return 'Something went wrong with the search'
   }
 }
 

--- a/server/utils/errorDisplayHelper.test.ts
+++ b/server/utils/errorDisplayHelper.test.ts
@@ -1,21 +1,10 @@
-import { SearchError } from '@searchEform'
 import { ValidationError, ValidationErrorItem } from 'joi'
 import { buildErrors, buildValidationErrors } from './errorDisplayHelper'
 
 describe('errorDisplayHelper', () => {
   describe('buildErrors', () => {
     it('returns errors for given error status', () => {
-      const searchError: SearchError = {
-        status: 500,
-        message: 'Something went wrong',
-      }
-
-      const result = buildErrors(searchError, (errorStatus: number): string => {
-        switch (errorStatus) {
-          default:
-            return 'Something went wrong with the search'
-        }
-      })
+      const result = buildErrors('Something went wrong with the search')
 
       expect(result).toEqual({ list: [{ href: '#', text: 'Something went wrong with the search' }] })
     })

--- a/server/utils/errorDisplayHelper.ts
+++ b/server/utils/errorDisplayHelper.ts
@@ -14,12 +14,12 @@ type Errors = {
   messages?: ErrorMessage
 }
 
-const buildErrors = (error: SearchError | CrmReportError, errorMessageFn: (errorStatus: number) => string): Errors => {
+const buildErrors = (errorMessage: string): Errors => {
   return {
     list: [
       {
         href: '#',
-        text: errorMessageFn(error.status),
+        text: errorMessage,
       },
     ],
   }

--- a/server/utils/errorDisplayHelper.ts
+++ b/server/utils/errorDisplayHelper.ts
@@ -1,5 +1,3 @@
-import { SearchError } from '@searchEform'
-import { CrmReportError } from '@crmReport'
 import Joi from 'joi'
 
 type ErrorMessage = Record<string, { text: string }>


### PR DESCRIPTION
**Changes made:**

- Simplified CrmReportResponse and SearchResponse to return only the error message.
- Moved getErrorMessage function from controller to service classes.
- Updated unit tests.