### PR TITLE
EMP-774: Fix CRM7 Schedule of Time field format

### DIFF
--- a/server/views/components/customDisplay/crm7/crm7ScheduleOfTime.njk
+++ b/server/views/components/customDisplay/crm7/crm7ScheduleOfTime.njk
@@ -26,7 +26,7 @@
             { text: item.feeEarnerInitials },
             { text: item.date },
             { text: item.costType },
-            { text: item.time | formatTime('HH:mm') },
+            { text: item.time | formatHours(true) },
             { text: item.hearingTypeCode },
             { text: item.personAttendedCode },
             { text: item.hourlyRate | formatCurrency },
@@ -56,7 +56,7 @@
     {% for item in data.laaAdjustments %}
         {% set row = [
             { text: item.line },
-            { text: item.time | formatTime('HH:mm') },
+            { text: item.time | formatHours(true) },
             { text: item.hourlyRate | formatCurrency },
             { text: item.basicClaim | formatCurrency },
             { text: item.uplift | formatPercentage },


### PR DESCRIPTION
**Changes made:**
- Used formatHours short format for time field in crm7ScheduleOfTime template.

