### PR TITLE
EMP-778: Restrict generate provider reports by user profile

### DIFF
--- a/server/controllers/generateReportController.test.ts
+++ b/server/controllers/generateReportController.test.ts
@@ -192,6 +192,7 @@ describe('GenerateReportController', () => {
         decisionFromDate: '2023-03-01',
         decisionToDate: '2023-03-30',
         providerAccount: '1234',
+        profileAcceptedTypes: '1,4,5,6',
       })
     })
   })

--- a/server/data/api/crmReportApiClient.test.ts
+++ b/server/data/api/crmReportApiClient.test.ts
@@ -79,6 +79,7 @@ describe('CRM Report Api Client', () => {
         providerAccount: '0D182J',
       })
       .matchHeader('authorization', 'Bearer no_auth')
+      .matchHeader('profileAcceptedTypes', '1,4,5,6')
       .reply(200, { text: 'provider,csv,data\n1,2,3' })
 
     const result = await crmReportApiClient.getProviderCrmReport({
@@ -111,6 +112,7 @@ describe('CRM Report Api Client', () => {
         providerAccount: '0D182J',
       })
       .matchHeader('authorization', 'Bearer no_auth')
+      .matchHeader('profileAcceptedTypes', '1,4,5,6')
       .reply(200, 'sample,csv,data\n4,5,6')
 
     const result = await crmReportApiClient.getProviderCrm14Report({
@@ -128,27 +130,5 @@ describe('CRM Report Api Client', () => {
     })
 
     expect(result.toString()).toEqual('sample,csv,data\n4,5,6')
-  })
-
-  it('should handle Provider CRM Report 404 error', async () => {
-    fakeRestClient
-      .get('/api/internal/v1/equinity/report/provider/crm4/')
-      .query({
-        decisionFrom: '2023-03-01',
-        decisionTo: '2023-03-30',
-        providerAccount: 'INVALID',
-      })
-      .matchHeader('authorization', 'Bearer no_auth')
-      .reply(404, { message: 'Not found' })
-
-    await expect(
-      crmReportApiClient.getProviderCrmReport({
-        crmType: 'crm4',
-        decisionFromDate: '2023-03-01',
-        decisionToDate: '2023-03-30',
-        providerAccount: 'INVALID',
-        profileAcceptedTypes: '1,4,5,6',
-      }),
-    ).rejects.toThrow('Not Found')
   })
 })

--- a/server/data/api/crmReportApiClient.ts
+++ b/server/data/api/crmReportApiClient.ts
@@ -27,11 +27,12 @@ export default class CrmReportApiClient {
   }
 
   async getProviderCrmReport(crmReportRequest: CrmReportRequest): Promise<superagent.Response> {
-    const { crmType, decisionFromDate, decisionToDate, providerAccount } = crmReportRequest
+    const { crmType, decisionFromDate, decisionToDate, providerAccount, profileAcceptedTypes } = crmReportRequest
     return CrmReportApiClient.restClient('Provider Report API client', 'no_auth').get<superagent.Response>({
       path: `/api/internal/v1/equinity/report/provider/${crmType}/`,
       headers: {
         ...this.headers,
+        profileAcceptedTypes,
       },
       query: {
         decisionFrom: decisionFromDate,
@@ -91,12 +92,14 @@ export default class CrmReportApiClient {
       lastSubmittedFromDate,
       lastSubmittedToDate,
       providerAccount,
+      profileAcceptedTypes,
     } = crmReportRequest
 
     return CrmReportApiClient.restClient('Provider Report API client', 'no_auth').get<string>({
       path: `/api/internal/v1/equinity/report/provider/${crmType}/`,
       headers: {
         ...this.headers,
+        profileAcceptedTypes,
       },
       responseType: 'blob',
       query: {

--- a/server/utils/generateReportHelper.test.ts
+++ b/server/utils/generateReportHelper.test.ts
@@ -46,7 +46,7 @@ describe('generateReportHelper', () => {
         decisionToDate: '2023-03-30',
         lastSubmittedFromDate: undefined,
         lastSubmittedToDate: undefined,
-        profileAcceptedTypes: undefined,
+        profileAcceptedTypes: '1,4,5,6',
         providerAccount: '1234AB',
         submittedFromDate: undefined,
         submittedToDate: undefined,

--- a/server/utils/generateReportHelper.ts
+++ b/server/utils/generateReportHelper.ts
@@ -17,7 +17,7 @@ export const buildReportRequest = (
     lastSubmittedFromDate: reportParams.lastSubmittedFromDate,
     lastSubmittedToDate: reportParams.lastSubmittedToDate,
     providerAccount: isProviderReport ? reportParams.providerAccount : undefined, // Include only for provider reports
-    profileAcceptedTypes: isProviderReport ? undefined : profileAcceptedTypes, // Set profileAcceptedTypes for non-provider reports
+    profileAcceptedTypes,
   }
 }
 

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -9,13 +9,21 @@
   <div class="govuk-width-container">
       <h1 class="govuk-heading-l">Access eForms Records</h1>
 
-      {{ displayHeading(isReportingAllowed, isProviderReportingAllowed, (isArchiveEnvironment or isViewEformAllowed)) }}
+      {% if isArchiveEnvironment %}
+          <p class="govuk-body">You can generate eForm reports.</p>
 
-      {{ displayLinks(isReportingAllowed, isProviderReportingAllowed, (isArchiveEnvironment or isViewEformAllowed)) }}
+          <p class="govuk-body">
+              <a href="/generate-report" class="govuk-link govuk-link--no-visited-state">Generate eForm reports</a>
+          </p>
+      {% else %}
+
+          {{ displayLinks(isReportingAllowed, isProviderReportingAllowed, isViewEformAllowed) }}
+
+      {% endif %}
   </div>
 {% endblock %}
 
-{% macro displayHeading(isReportingAllowed, isProviderReportingAllowed, isViewEformAllowed) %}
+{% macro displayLinks(isReportingAllowed, isProviderReportingAllowed, isViewEformAllowed) %}
     {% set headingParts = [] %}
 
     {% if isReportingAllowed %}
@@ -39,9 +47,6 @@
             You can {{ headingParts[0] }}, {{ headingParts[1] }} or {{ headingParts[2] }}.
         {% endif %}
     </p>
-{% endmacro %}
-
-{% macro displayLinks(isReportingAllowed, isProviderReportingAllowed, isViewEformAllowed) %}
 
     {% if isReportingAllowed %}
         <p class="govuk-body">


### PR DESCRIPTION
Changes made:

- Modified crmReportApiClient to send profileAcceptedTypes header to BE provider reports APIs
- Fixed links for archive environment
- Update unit tests